### PR TITLE
build: move installed items into subdirectories

### DIFF
--- a/src/demos/rman/CMakeLists.txt
+++ b/src/demos/rman/CMakeLists.txt
@@ -41,7 +41,7 @@ link_directories($ENV{RMANTREE}/lib)
 add_library(SeExprOp SHARED seop.cpp)
 target_link_libraries(SeExprOp prman ${SEEXPR_LIBRARIES})
 FILE(GLOB ribs "*.rib")
-install (TARGETS SeExprOp DESTINATION prman)
+install (TARGETS SeExprOp DESTINATION ${CMAKE_INSTALL_LIBDIR}/prman)
 
 foreach (SHADERSOURCE testdisp testse)
     ADD_CUSTOM_COMMAND(
@@ -52,7 +52,7 @@ foreach (SHADERSOURCE testdisp testse)
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${SHADERSOURCE}.sl SeExprOp
     )
     add_custom_target(shader-${SHADERSOURCE} ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${SHADERSOURCE}.slo)
-    INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/${SHADERSOURCE}.slo DESTINATION prman)
+    INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/${SHADERSOURCE}.slo DESTINATION ${CMAKE_INSTALL_LIBDIR}/prman)
 endforeach(SHADERSOURCE)
-install (FILES ${ribs} DESTINATION prman)
+install (FILES ${ribs} DESTINATION ${CMAKE_INSTALL_LIBDIR}/prman)
 endif(NOT ${RMAN_SET})

--- a/src/demos/segraph/CMakeLists.txt
+++ b/src/demos/segraph/CMakeLists.txt
@@ -38,7 +38,7 @@ if(QT4_FOUND)
     qt4_wrap_cpp(segraph_MOC_SRCS ${segraph_MOC_HDRS})
     
     add_executable(segraph ${segraph_CPPS} ${segraph_MOC_SRCS})
-    install(TARGETS segraph DESTINATION demo)
+    install(TARGETS segraph DESTINATION share/SeExpr/demo)
     INCLUDE_DIRECTORIES(${QT_INCLUDE_DIR})
     target_link_libraries(segraph ${QT_QTCORE_LIBRARY})
     target_link_libraries(segraph ${QT_QTGUI_LIBRARY})

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -34,5 +34,5 @@
 foreach(item basic)
     ADD_EXECUTABLE(${item} "${item}.cpp")
     target_link_libraries(${item} ${SEEXPR_LIBRARIES})
-    install(TARGETS ${item} DESTINATION test)
+    install(TARGETS ${item} DESTINATION share/test/SeExpr)
 endforeach(item)


### PR DESCRIPTION
Keep the top-level namespace clean by pushing the "demo" and "prman"
directories down into subdirectories.
