### PR TITLE
SeExprBuiltins.h: fix remap declaration

### DIFF
--- a/src/SeExpr/SeExprBuiltins.h
+++ b/src/SeExpr/SeExprBuiltins.h
@@ -58,7 +58,7 @@ namespace SeExpr
     double linearstep(double x, double a, double b);
     double smoothstep(double x, double a, double b);
     double gaussstep(double x, double a, double b);
-    double remap(double x, double s, double r, double f, int interp);
+    double remap(double x, double s, double r, double f, double interp);
     double mix(double x, double y, double alpha);
     SeVec3d hsi(int n, const SeVec3d* args);
     SeVec3d midhsi(int n, const SeVec3d* args);


### PR DESCRIPTION
SeExpr::remap() takes 5 doubles, not 4 doubles and an int.

Signed-off-by: David Aguilar <davvid@gmail.com>