### PR TITLE
Plugin not found prints errors

### DIFF
--- a/src/SeExpr/SeExprFunc.cpp
+++ b/src/SeExpr/SeExprFunc.cpp
@@ -232,10 +232,6 @@ SeExprFunc::loadPlugins(const char* path)
 			free(matches[i]);
 	    }
 	    if (matches) free(matches);
-	    else {
-		std::cerr << "No plugins found matching "
-			  << path << "/SeExpr*.so" << std::endl;
-	    }
 	}
 
 	entry = strtok_r(0, ":", &state);


### PR DESCRIPTION
In SeExprFunc::loadPlugins, if the path being looked at is a directory, and no plugins are found, an error is printed to stderr (line SeExprFunc.cpp:235-238).  This feels at odds with "most apps" where they can be pointed to a plugin path that may or may not exist, and have that be treated as a no-op if it doesn't.  Would there be any objections to commenting/deleting this bit of printing code?