### PR TITLE
build: ask Python for the path to its header files

### DIFF
--- a/src/SeExprEditor/CMakeLists.txt
+++ b/src/SeExprEditor/CMakeLists.txt
@@ -24,6 +24,7 @@ macro(get_build_info NAME STORAGE)
 endmacro()
 
 get_build_info(python-site PYTHON_SITE)
+get_build_info(python-inc PYTHON_INCLUDE_DIR)
 get_build_info(sip-inc SIP_INCLUDE_DIR)
 get_build_info(pyqt4-sip PYQT4_SIP)
 
@@ -90,7 +91,7 @@ ENDIF(WIN32)
     set(CMAKE_CXX_FLAGS "-std=c++0x")
     set(CMAKE_INSTALL_PYTHON "${PYTHON_SITE}/SeExpr" )
     include_directories(${SIP_INCLUDE_DIR} ${PYQT4_SIP}
-                        ${PYTHON_INCLUDE_DIRS} ${QT_INCLUDE_DIR}/QtCore
+                        ${PYTHON_INCLUDE_DIR} ${QT_INCLUDE_DIR}/QtCore
                         ${QT_INCLUDE_DIR}/QtGui)
 
     add_custom_command(OUTPUT sipexpreditorpart0.cpp

--- a/src/build/build-info
+++ b/src/build/build-info
@@ -19,6 +19,7 @@ def main():
 
     callbacks = (
         ('python-site', python_site),
+        ('python-inc', python_inc),
         ('pyqt4-sip', pyqt4_sip),
         ('sip-inc', sip_inc),
     )
@@ -42,6 +43,10 @@ def lib(args):
 
 def python_ver(args):
     return sc.get_python_version()
+
+
+def python_inc(args):
+    return sc.get_config_var('CONFINCLUDEPY')
 
 
 def python_site(args):


### PR DESCRIPTION
CMake can sometimes guess the wrong path to Python's header files.
Ask Python for the path directly.