### PR TITLE
cherry-pick Disney internal changes:

### DIFF
--- a/src/SeExpr/CMakeLists.txt
+++ b/src/SeExpr/CMakeLists.txt
@@ -16,66 +16,7 @@
 
 FILE(GLOB io_cpp "*.cpp")
 
-
-## find our parser generators
-#find_program(BISON_EXE bison)
-#find_program(FLEX_EXE flex)
-#find_program(SED_EXE sed)
-#
-#if((BISON_EXE STREQUAL "BISON_EXE-NOTFOUND") OR (FLEX_EXE STREQUAL "FLEX_EXE-NOTFOUND")  OR (SED_EXE STREQUAL "SED_EXE-NOTFOUND"))
-#     # don't have flex/bison/sed, use pregenerated versions
-#    set (parser_cpp generated/SeExprParser.cpp generated/SeExprParserLex.cpp )
-#else ((BISON_EXE STREQUAL "BISON_EXE-NOTFOUND") OR (FLEX_EXE STREQUAL "FLEX_EXE-NOTFOUND")  OR (SED_EXE STREQUAL "SED_EXE-NOTFOUND"))
-#     ## build the parser from the flex/yacc sources
-#
-#    ADD_CUSTOM_COMMAND(
-#      SOURCE "SeExprParserLex.l"
-#      COMMAND "flex"
-#      ARGS "-oSeExprParserLexIn.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/SeExprParserLex.l"
-#      OUTPUT SeExprParserLexIn.cpp
-#      DEPENDS SeExprParserLex.l
-#    )
-#    
-#    ADD_CUSTOM_COMMAND(
-#      SOURCE "SeExprParserLexIn.cpp"
-#      COMMAND "sed"
-##      ARGS -e "'s/SeExprwrap(n)/SeExprwrap()/g'" -e "'s/yy/SeExpr/g'" -e "'s/YY/SeExprYY/g'"  SeExprParserLexIn.cpp | tee SeExprParserLex.cpp ${CMAKE_CURRENT_SOURCE_DIR}/generated/SeExprParserLex.cpp > /dev/null
-#      ARGS -e "'s/SeExprwrap(n)/SeExprwrap()/g'" -e "'s/yy/SeExpr/g'" -e "'s/YY/SeExprYY/g'"  SeExprParserLexIn.cpp | tee SeExprParserLex.cpp ${CMAKE_CURRENT_SOURCE_DIR}/generated/SeExprParserLex.cpp > /dev/null
-#      OUTPUT SeExprParserLex.cpp
-#      DEPENDS SeExprParserLexIn.cpp
-#    )
-#    
-#    ADD_CUSTOM_COMMAND(
-#      SOURCE "SeExprParser.y"
-#      COMMAND "bison"
-#      ARGS "--defines" "--verbose" "--fixed-output-files" "-p" "SeExpr" "${CMAKE_CURRENT_SOURCE_DIR}/SeExprParser.y"
-#      OUTPUT y.tab.c y.tab.h
-#      DEPENDS SeExprParser.y
-#    )
-#    
-#    ADD_CUSTOM_COMMAND(
-#      SOURCE "y.tab.h"
-#      COMMAND "sed"
-#      ARGS -e "'s/yy/SeExpr/g'" -e "'s/YY/SeExprYY/g'" y.tab.h | tee  SeExprParser.tab.h ${CMAKE_CURRENT_SOURCE_DIR}/generated/SeExprParser.tab.h > /dev/null
-#      OUTPUT SeExprParser.tab.h
-#      DEPENDS y.tab.h
-#    )
-#    
-#    ADD_CUSTOM_COMMAND(
-#      SOURCE "y.tab.c"
-#      COMMAND "sed"
-#      ARGS -e "'s/yy/SeExpr/g'" -e "'s/YY/SeExprYY/g'" y.tab.c | tee SeExprParser.cpp  "${CMAKE_CURRENT_SOURCE_DIR}/generated/SeExprParser.cpp" > /dev/null
-#      OUTPUT SeExprParser.cpp
-#      DEPENDS y.tab.c SeExprParser.tab.h
-#    )
-#
-#    ## set build files
-#    set (parser_cpp SeExprParser.cpp SeExprParserLex.cpp )
-#
-#endif( (BISON_EXE STREQUAL "BISON_EXE-NOTFOUND") OR (FLEX_EXE STREQUAL "FLEX_EXE-NOTFOUND")  OR (SED_EXE STREQUAL "SED_EXE-NOTFOUND"))
-
 BuildParserScanner(SeExprParserLex SeExprParser SeExpr parser_cpp)
-
 
 ## Make the SeExpr library
 ADD_LIBRARY (SeExpr SHARED ${io_cpp} ${core_cpp} ${parser_cpp})

--- a/src/SeExpr/SeCurve.h
+++ b/src/SeExpr/SeCurve.h
@@ -14,8 +14,7 @@
 * You may obtain a copy of the License at
 * http://www.apache.org/licenses/LICENSE-2.0
 */
-#ifndef _CurveData_h_
-#define _CurveData_h_
+#pragma once
 
 #include "SeVec3d.h"
 #include <vector>
@@ -88,4 +87,3 @@ private:
 };
 
 }
-#endif

--- a/src/SeExpr/SeExprBuiltins.cpp
+++ b/src/SeExpr/SeExprBuiltins.cpp
@@ -36,7 +36,7 @@ static const char* fabs_docstring="float abs(float x)\nabsolute value of x";
 
 // angle conversion functions
 static const char* deg_docstring="float deg(float angle)\nradians to degrees";
-static const char* rad_docstring="float deg(float angle)\ndegrees to radians";
+static const char* rad_docstring="float rad(float angle)\ndegrees to radians";
 // trig in degrees
 static const char* cosd_docstring="float cosd(float angle)\ncosine in degrees";
 static const char* sind_docstring="float sind(float angle)\nsine in degrees";

--- a/src/SeExpr/SeExprFunc.cpp
+++ b/src/SeExpr/SeExprFunc.cpp
@@ -65,6 +65,32 @@ namespace {
         void initIfNeeded();
 	void initBuiltins();
 
+
+        size_t sizeInBytes() const{
+            size_t totalSize=0;
+            for(FuncMap::const_iterator it=funcmap.begin();it!=funcmap.end();++it){
+                totalSize+=it->first.size()+sizeof(FuncMapItem);
+                const SeExprFunc& function=it->second.second;
+                if(function.type()==SeExprFunc::FUNCX){
+                    totalSize+=function.funcx()->sizeInBytes();
+                }
+            }
+            return totalSize;
+        }
+
+        SeStatistics statistics() const{
+            SeStatistics statisticsDump;
+            size_t totalSize=0;
+            for(FuncMap::const_iterator it=funcmap.begin();it!=funcmap.end();++it){
+                totalSize+=it->first.size()+sizeof(FuncMapItem);
+                const SeExprFunc& function=it->second.second;
+                if(function.type()==SeExprFunc::FUNCX){
+                    function.funcx()->statistics(statisticsDump);
+                }
+            }
+            return statisticsDump;
+        }
+
         void getFunctionNames(std::vector<std::string>& names)
         {
             for(FuncMap::iterator i=funcmap.begin();i!=funcmap.end();++i)
@@ -188,6 +214,19 @@ SeExprFunc::getDocString(const char* functionName)
     std::string ret=Functions.getDocString(functionName);
     mutex.unlock();
     return ret;
+}
+
+size_t
+SeExprFunc::sizeInBytes(){
+    SeExprInternal::AutoMutex locker(mutex);
+    Functions.initIfNeeded();
+    return Functions.sizeInBytes();
+}
+
+SeStatistics SeExprFunc::statistics() {
+    SeExprInternal::AutoMutex locker(mutex);
+    Functions.initIfNeeded();
+    return Functions.statistics();
 }
 
 #ifndef SEEXPR_WIN32

--- a/src/SeExpr/SeExprFunc.h
+++ b/src/SeExpr/SeExprFunc.h
@@ -19,9 +19,13 @@
 
 #include "SeVec3d.h"
 #include <vector>
+#include <map>
 
 class SeExpression;
 class SeExprFuncNode;
+
+/// SeStatistics
+typedef std::map<std::string,double> SeStatistics;
 
 //! Extension function spec, used for complicated argument custom functions.
 /** Provides the ability to handle all argument type checking and processing manually.
@@ -49,6 +53,13 @@ public:
     virtual ~SeExprFuncX(){}
 
     bool isThreadSafe() const {return _threadSafe;}
+
+    /// Return memory usage of a funcX in bytes.
+    virtual size_t sizeInBytes() const {return 0;}
+
+    /// Give this function a chance to populate its statistics
+    virtual void statistics(SeStatistics& /*statistics*/) const {}
+
 private:
     bool _threadSafe;
 };
@@ -95,6 +106,13 @@ public:
 
     //! Get doc string for a specific function
     static std::string getDocString(const char* functionName);
+
+    //! Get the total size estimate of all plugins
+    static size_t sizeInBytes();
+
+    //! Dump statistics
+    static SeStatistics statistics();
+
 
     typedef double Func0();
     typedef double Func1(double);

--- a/src/SeExprEditor/SeExprEdControl.cpp
+++ b/src/SeExprEditor/SeExprEdControl.cpp
@@ -383,7 +383,7 @@ void SeExprEdNumberControl::setValue(float value)
 }
 
 SeExprEdVectorControl::SeExprEdVectorControl(int id,SeExprEdVectorEditable* editable)
-    :SeExprEdControl(id,editable,true),_numberEditable(editable)
+    :SeExprEdControl(id,editable,true),_numberEditable(editable),_swatch(0)
 {
 
     if(_numberEditable->isColor){


### PR DESCRIPTION
-- fix rad) function documentation type
-- Add ability to register function stats and query them. also allow querying sizes.
-- remove commented bison/flex stuff
-- fixes SEEXPR-166: crashes occurring when editing numeric vector values
-- fix duplicate header includes between v1 and v2