### PR TITLE
removed windows compile incompatibilities

### DIFF
--- a/src/SeExpr/ExprConfig.h.in
+++ b/src/SeExpr/ExprConfig.h.in
@@ -17,7 +17,7 @@
 #pragma once
 
 // This should be substituted externally by CMake
-#if @SEEXPR_ENABLE_LLVM_BACKEND@
+#if @ENABLE_LLVM_BACKEND@
 #	define	SEEXPR_ENABLE_LLVM
 #endif
 

--- a/src/SeExpr/ExprNode.cpp
+++ b/src/SeExpr/ExprNode.cpp
@@ -18,6 +18,7 @@
 #ifndef MAKEDEPEND
 #include <math.h>
 #include <sstream>
+#include <algorithm>
 #endif
 #include "Vec.h"
 #include "ExprType.h"

--- a/src/SeExpr/Expression.cpp
+++ b/src/SeExpr/Expression.cpp
@@ -32,10 +32,10 @@
 #include "Platform.h"
 
 #include "Evaluator.h"
+#include "ExprWalker.h"
 
 #include <cstdio>
 #include <typeinfo>
-#include <ExprWalker.h>
 
 namespace SeExpr2 {
 
@@ -45,8 +45,7 @@ bool Expression::debugging = getenv("SE_EXPR_DEBUG") != 0;
 // And the environment variables SE_EXPR_DEBUG
 static Expression::EvaluationStrategy chooseDefaultEvaluationStrategy() {
     if (Expression::debugging) {
-        std::cerr << "SeExpr2 Debug Mode Enabled " << __VERSION__ << " built " << __DATE__ << " " << __TIME__
-                  << std::endl;
+        std::cerr << "SeExpr2 Debug Mode Enabled " << std::endl;
     }
 #ifdef SEEXPR_ENABLE_LLVM
     if (char* env = getenv("SE_EXPR_EVAL")) {

--- a/src/SeExpr/Interpreter.cpp
+++ b/src/SeExpr/Interpreter.cpp
@@ -19,7 +19,8 @@
 #include "VarBlock.h"
 #include <iostream>
 #include <cstdio>
-#include <dlfcn.h>
+#include <algorithm>
+//#include <dlfcn.h>
 
 // TODO: optimize to write to location directly on a CondNode
 namespace SeExpr2 {
@@ -48,9 +49,9 @@ void Interpreter::eval(VarBlock* block, bool debug) {
 void Interpreter::print(int pc) const {
     std::cerr << "---- ops     ----------------------" << std::endl;
     for (size_t i = 0; i < ops.size(); i++) {
-        Dl_info info;
+      //  Dl_info info;
         const char* name = "";
-        if (dladdr((void*)ops[i].first, &info)) name = info.dli_sname;
+      //  if (dladdr((void*)ops[i].first, &info)) name = info.dli_sname;
         fprintf(stderr, "%s %s %p (", pc == (int)i ? "-->" : "   ", name, ops[i].first);
         int nextGuy = (i == ops.size() - 1 ? opData.size() : ops[i + 1].second);
         for (int k = ops[i].second; k < nextGuy; k++) {

--- a/src/SeExpr/Noise.cpp
+++ b/src/SeExpr/Noise.cpp
@@ -96,7 +96,7 @@ T noiseHelper(const T* X, const int* period = 0) {
         weights[1][k] = weights[0][k] - 1;  // dist to cell with index one above
     }
     // compute function values propagated from zero from each node
-    int num = 1 << d;
+    const int num = 1 << d;
     T vals[num];
     for (int dummy = 0; dummy < num; dummy++) {
         int latticeIndex[d];

--- a/src/SeExpr/Platform.h
+++ b/src/SeExpr/Platform.h
@@ -62,7 +62,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <assert.h>
-#include <sys/time.h>
+//#include <sys/time.h>
 
 // missing functions on Windows
 #ifdef WINDOWS
@@ -130,6 +130,7 @@ class Timer {
 
     void start() { std::cerr << "timer not implemented on Windows" << std::endl; }
     long elapsedTime() { return 0; }
+    bool started;
 };
 #endif
 

--- a/src/SeExpr/Vec.h
+++ b/src/SeExpr/Vec.h
@@ -40,7 +40,9 @@ struct my_enable_if {
 };
 //! Enable_if failure case (substitution failure is not an error)
 template <class T>
-struct my_enable_if<false, T> {};
+struct my_enable_if<false, T> { 
+    typedef T TYPE;
+};
 
 //! Static conditional type true case
 template <bool c, class T1, class T2>


### PR DESCRIPTION
while compiling on windows 10 / VS 2015 I came across some glitches that I fixed, here some details:

 src/SeExpr/ExprConfig.h.in - SEEXPR_ENABLE_LLVM_BACKEND only gets generated when compiling with LLVM, replacing it with ENABLE_LLVM_BACKEND makes it work

src/SeExpr/ExprNode.cpp - need to include algorithm for min/max

src/SeExpr/Expression.cpp - **VERSION** does not exist on windows, removed it

 src/SeExpr/Interpreter.cpp - removed dlfcn, not really needed and incompatible with windows

src/SeExpr/Noise.cpp - compiler barfed about the const, so I added it

src/SeExpr/Platform.h - sys/time.h is gone on windows, removed it and added the missing bool to the class

 src/SeExpr/Vec.h - had to add the TYPE for it to compile

This is for SeExpr src only, to build the libs. I did not test any of the ui/utils/tests etc.
