### PR TITLE
Fix string support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,11 +81,11 @@ set(LLVM_LIB "")
 if (ENABLE_LLVM_BACKEND)
     set(LLVM_DIR /usr/share/llvm/cmake CACHE PATH "Where to search for LLVM i.e. ")
 
-    find_package(LLVM CONFIG NAMES LLVM CONFIGS LLVM-Config.cmake)
+    find_package(LLVM CONFIG NAMES LLVM CONFIGS LLVMConfig.cmake)
     if (LLVM_FOUND)
         set(SEEXPR_ENABLE_LLVM_BACKEND 1)
-        message(STATUS "Using LLVM-Config.cmake in: ${LLVM_DIR}")
-        find_program(LLVM_CONFIG_EXECUTABLE NAMES llvm-config-3.8 llvm-config)
+        message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+        find_program(LLVM_CONFIG_EXECUTABLE NAMES ${LLVM_TOOLS_BINARY_DIR}/llvm-config)
 
         # Uncomment to use clang++
         #set(CMAKE_CXX_COMPILER clang++)

--- a/src/SeExpr/Expression.cpp
+++ b/src/SeExpr/Expression.cpp
@@ -338,7 +338,7 @@ const char* Expression::evalStr(VarBlock* varBlock) const {
             _interpreter->eval(varBlock);
             return _interpreter->s[_returnSlot];
         } else {  // useLLVM
-            _llvmEvaluator->evalStr(varBlock);
+            return _llvmEvaluator->evalStr(varBlock);
         }
     }
     return 0;

--- a/src/SeExpr/Interpreter.cpp
+++ b/src/SeExpr/Interpreter.cpp
@@ -299,7 +299,11 @@ struct JmpRelative {
 struct EvalVar {
     static int f(int* opData, double* fp, char** c, std::vector<int>& callStack) {
         ExprVarRef* ref = reinterpret_cast<ExprVarRef*>(c[opData[0]]);
-        ref->eval(fp + opData[1]);  // ,c+opData[1]);
+        if (ref->type().isFP()) {
+            ref->eval(fp + opData[1]);
+        } else {
+            ref->eval(const_cast<const char**>(c + opData[1]));
+        }
         return 1;
     }
 };
@@ -462,7 +466,7 @@ int ExprLocalFunctionNode::buildInterpreterForCall(const ExprFuncNode* callerNod
     int returnAddress = interpreter->addOperand(0);
     interpreter->addOperand(_procedurePC - basePC);
     interpreter->endOp(false);
-    // set return address
+    // set return address
     interpreter->opData[returnAddress] = interpreter->nextPC();
 
     // TODO: copy result back and string

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -59,7 +59,7 @@ if(EXISTS ${GTEST_DIR}/include)
                 /disney/shows/default/rel/global/expressions)
         endif()
 
-        add_executable(testmain2 "testmain.cpp" "imageTests.cpp" "testSeExprExamples.cpp" ${PAINT3D_SRC} "basic.cpp")
+        add_executable(testmain2 "testmain.cpp" "imageTests.cpp" "testSeExprExamples.cpp" ${PAINT3D_SRC} "basic.cpp" "string.cpp")
         target_link_libraries(testmain2 SeExpr2 gtest ${PNG_LIBRARIES})
         install(TARGETS testmain2 DESTINATION share/test/SeExpr2)
         install(PROGRAMS imagediff.py DESTINATION share/test/SeExpr2)

--- a/src/tests/string.cpp
+++ b/src/tests/string.cpp
@@ -1,0 +1,128 @@
+/*
+* Copyright Disney Enterprises, Inc.  All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License
+* and the following modification to it: Section 6 Trademarks.
+* deleted and replaced with:
+*
+* 6. Trademarks. This License does not grant permission to use the
+* trade names, trademarks, service marks, or product names of the
+* Licensor and its affiliates, except as required for reproducing
+* the content of the NOTICE file.
+*
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+#include <gtest/gtest.h>
+
+#include <SeExpr2/Expression.h>
+#include <SeExpr2/ExprFunc.h>
+
+using namespace SeExpr2;
+
+
+struct StringFunc : public ExprFuncSimple {
+    StringFunc() : ExprFuncSimple(true) {}
+
+    struct StringData : public SeExpr2::ExprFuncNode::Data
+    {
+        std::string str;
+        int numArgs;
+    };
+
+    virtual ExprType prep(ExprFuncNode* node, bool scalarWanted, ExprVarEnvBuilder& envBuilder) const {
+        bool constant = true;
+        for (int i = 0, iend = node->numChildren(); i < iend; ++i) {
+            SeExpr2::ExprType t = node->child(i)->prep(!scalarWanted, envBuilder);
+            if (t.isString() == false) {
+                return SeExpr2::ExprType().Error().Varying();
+            }
+            if (t.isLifetimeConstant() == false) {
+                constant = false;
+            }
+        }
+        return constant == true ? SeExpr2::ExprType().String().Constant() : SeExpr2::ExprType().String().Varying();
+    }
+    virtual ExprFuncNode::Data* evalConstant(const ExprFuncNode* node, ArgHandle args) const {
+        StringData* data = new StringData();
+        data->numArgs = node->numChildren();
+        return data;
+    }
+    virtual void eval(ArgHandle args) {
+        StringData* data = reinterpret_cast<StringData*>(args.data);
+        data->str.clear();
+        for (int i = 0; i < data->numArgs; ++i) {
+            data->str += args.inStr(i);
+            if (i != data->numArgs - 1) {
+                data->str += "/";
+            }
+        }
+        args.outStr = const_cast<char*>(data->str.c_str());
+    }
+} joinPath;
+ExprFunc joinPathFunc(joinPath, 2, 100);
+
+
+struct StringExpression : public Expression {
+    // Define simple string variable type that just stores the value it returns
+    struct Var : public ExprVarRef {
+        std::string value;
+        Var() : ExprVarRef(ExprType().String().Varying()) {}
+        void eval(double*) { }
+        void eval(const char** result) { result[0] = value.c_str(); }
+        Var& operator = (const char* input) { value = input; return *this; }
+    };
+    mutable Var stringVar;
+
+    // Custom variable resolver, only allow ones we specify
+    ExprVarRef* resolveVar(const std::string& name) const {
+        if (name == "stringVar") return &stringVar;
+        return 0;
+    }
+
+    // Custom function resolver
+    ExprFunc* resolveFunc(const std::string& name) const {
+        if (name == "join_path") return &joinPathFunc;
+        return 0;
+    }
+
+    // Constructor
+    StringExpression(const std::string& str)
+        : Expression(str, ExprType().String()) {}
+};
+
+TEST(StringTests, Constant) {
+    StringExpression expr("\"hello world !\"");
+    EXPECT_TRUE(expr.isValid() == true);
+    EXPECT_TRUE(expr.returnType().isString() == true);
+    EXPECT_TRUE(expr.isConstant() == true);
+    EXPECT_STREQ(expr.evalStr(), "hello world !");
+}
+
+TEST(StringTests, Variable) {
+    StringExpression expr("stringVar");
+    expr.stringVar = "hey, it's working !";
+    EXPECT_TRUE(expr.isValid());
+    EXPECT_TRUE(expr.returnType().isString());
+    EXPECT_TRUE(!expr.isConstant());
+    EXPECT_STREQ(expr.evalStr(), "hey, it's working !");
+}
+
+TEST(StringTests, FunctionConst) {
+    StringExpression expr("join_path(\"/home/foo\", \"some\", \"relative\", \"path\")");
+    EXPECT_TRUE(expr.isValid() == true);
+    EXPECT_TRUE(expr.returnType().isString() == true);
+    EXPECT_TRUE(expr.isConstant() == true);
+    EXPECT_STREQ(expr.evalStr(), "/home/foo/some/relative/path");
+}
+
+TEST(StringTests, FunctionVarying) {
+    StringExpression expr("join_path(stringVar, \"some\", \"relative\", \"path\")");
+    expr.stringVar = "/home/foo";
+    EXPECT_TRUE(expr.isValid() == true);
+    EXPECT_TRUE(expr.returnType().isString() == true);
+    EXPECT_TRUE(expr.isConstant() == false);
+    EXPECT_STREQ(expr.evalStr(), "/home/foo/some/relative/path");
+}


### PR DESCRIPTION
Hi,

The first commit is a small fix to the CMake script to allow using a custom version of LLVM. The problem was that the script was allowing to set a LLVM_DIR option, but then it didn't use the configured paths to look for the llvm-config tool. So I had an old LLVM lib installed on my system that was always used, instead of the one I specified using the LLVM_DIR option.

The second commit adds support for strings in expressions. Now expressions can correctly return strings (through the evalStr method), user functions can also return strings, and user variables can be strings. I didn't test with evalMultiple or VarBlocks though ...

Anyway, let me know what you think of this, I can update this pull request as much as needed :)