### PR TITLE
Made build more resilient for newer PyQt4 versions. Fixes #58.

### DIFF
--- a/src/build/build-info
+++ b/src/build/build-info
@@ -11,7 +11,6 @@ if 'MACOSX_DEPLOYMENT_TARGET' in os.environ:
 from distutils import sysconfig as sc
 
 import sipconfig
-from PyQt4 import pyqtconfig
 
 def main():
     parser = argparse.ArgumentParser()
@@ -56,6 +55,7 @@ def python_site(args):
 
 
 def pyqt4_sip(args):
+    from PyQt4 import pyqtconfig
     pkg_cfg = pyqtconfig._pkg_config
     return pkg_cfg['pyqt_sip_dir']
 

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -28,7 +28,15 @@ endmacro()
 get_build_info(python-site PYTHON_SITE)
 get_build_info(python-inc PYTHON_INCLUDE_DIR)
 get_build_info(sip-inc SIP_INCLUDE_DIR)
-get_build_info(pyqt4-sip PYQT4_SIP)
+
+list(APPEND CMAKE_MODULE_PATH "/usr/share/apps/cmake/modules/") # needed for e.g Arch Linux as new versions of CMake only search a version-specific module path. Should be no problem if the path does not exist.
+find_package(PyQt4)
+set(PYQT4_SIP ${PYQT4_SIP_DIR})
+if(PYQT4_FOUND)
+
+else()
+  get_build_info(pyqt4-sip PYQT4_SIP)
+endif()
 
 set(CMAKE_INSTALL_PYTHON "${PYTHON_SITE}/SeExpr2" )
 

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -29,13 +29,14 @@ get_build_info(python-site PYTHON_SITE)
 get_build_info(python-inc PYTHON_INCLUDE_DIR)
 get_build_info(sip-inc SIP_INCLUDE_DIR)
 
-list(APPEND CMAKE_MODULE_PATH "/usr/share/apps/cmake/modules/") # needed for e.g Arch Linux as new versions of CMake only search a version-specific module path. Should be no problem if the path does not exist.
+if (EXISTS "/usr/share/apps/cmake/modules")
+    # Needed for some versions of CMake, which only look in version-specific module path
+    list(APPEND CMAKE_MODULE_PATH "/usr/share/apps/cmake/modules")
+endif()
 find_package(PyQt4)
 set(PYQT4_SIP ${PYQT4_SIP_DIR})
-if(PYQT4_FOUND)
-
-else()
-  get_build_info(pyqt4-sip PYQT4_SIP)
+if (NOT PYQT4_FOUND)
+    get_build_info(pyqt4-sip PYQT4_SIP)
 endif()
 
 set(CMAKE_INSTALL_PYTHON "${PYTHON_SITE}/SeExpr2" )


### PR DESCRIPTION
This should fix #58 in a way that brings a working build on current Arch Linux (ie all library versions are relatively new) closer and at the same doesn't break on other systems.