### PR TITLE
Add version check for LLVM 4 and Python 3 support. Fixes #72.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,14 @@ message(STATUS "CMAKE_INSTALL_LIBDIR = ${CMAKE_INSTALL_LIBDIR}")
 # Configuration options
 # TODO: find GTEST and boost and python the proper ways
 set(BOOST_DIR /usr CACHE PATH "where boost is located")
-set(BOOST_PYTHON_LIBNAME boost_python CACHE STRING "what library name for boost python")
+find_package(PythonInterp) # provides Python version check
+if(PYTHON_VERSION_MAJOR LESS 3)
+    set(BOOST_PYTHON_LIBNAME boost_python CACHE STRING "what library name for boost python")
+else()
+    # try to find boost_python3 in a way compatible with most distributions
+    find_library(BOOST_PYTHON3_LIB NAMES "boost_python3" "boost_python3${PYTHON_VERSION_MINOR}")
+    SET (BOOST_PYTHON_LIBNAME ${BOOST_PYTHON3_LIB} CACHE STRING "what library name for boost python")
+endif()
 set(GTEST_DIR /usr CACHE PATH "Where to find GTEST") # /usr/include/gtest)
 set(ENABLE_LLVM_BACKEND ON CACHE BOOL "Whether to build with LLVM backend")
 set(USE_PYTHON ON CACHE BOOL "Whether to compile python libraries")

--- a/src/SeExpr/Evaluator.h
+++ b/src/SeExpr/Evaluator.h
@@ -19,6 +19,10 @@
 #include "ExprLLVMAll.h"
 #include "VarBlock.h"
 
+#ifdef SEEXPR_ENABLE_LLVM
+#include <llvm/Support/Compiler.h>
+#endif
+
 extern "C" void SeExpr2LLVMEvalFPVarRef(SeExpr2::ExprVarRef *seVR, double *result);
 extern "C" void SeExpr2LLVMEvalStrVarRef(SeExpr2::ExprVarRef *seVR, double *result);
 extern "C" void SeExpr2LLVMEvalCustomFunction(int *opDataArg,
@@ -296,7 +300,11 @@ class LLVMEvaluator {
         std::unique_ptr<llvm::legacy::PassManager> pm(new llvm::legacy::PassManager);
         std::unique_ptr<llvm::legacy::FunctionPassManager> fpm(new llvm::legacy::FunctionPassManager(altModule));
         builder.OptLevel = 3;
+#if (LLVM_VERSION_MAJOR >= 4)
+        builder.Inliner = llvm::createAlwaysInlinerLegacyPass();
+#else
         builder.Inliner = llvm::createAlwaysInlinerPass();
+#endif
         builder.populateModulePassManager(*pm);
         // fpm->add(new llvm::DataLayoutPass());
         builder.populateFunctionPassManager(*fpm);

--- a/src/ui/SeExpr2Editor.sip
+++ b/src/ui/SeExpr2Editor.sip
@@ -15,7 +15,12 @@
     newstring = PyUnicode_DecodeUTF8(sipCpp->c_str(), sipCpp->length(), NULL);
     if(newstring == NULL) {
         PyErr_Clear();
+
+#if PY_MAJOR_VERSION < 3
         newstring = PyString_FromString(sipCpp->c_str());
+#else
+        newstring = PyUnicode_FromString(sipCpp->c_str());
+#endif
     }
     return newstring;
 %End
@@ -26,21 +31,31 @@
      // If argument is a Unicode string, just decode it to UTF-8
      // If argument is a Python string, assume it's UTF-8
      if (sipIsErr == NULL)
+#if PY_MAJOR_VERSION < 3
                 return (PyString_Check(sipPy) || PyUnicode_Check(sipPy));
+#else
+                return PyUnicode_Check(sipPy);
+#endif
         if (sipPy == Py_None) {
                 *sipCppPtr = new std::string;
                 return 1;
         }
         if (PyUnicode_Check(sipPy))        {
         PyObject* s = PyUnicode_AsEncodedString(sipPy, "UTF-8", "");
+#if PY_MAJOR_VERSION < 3
         *sipCppPtr = new std::string(PyString_AS_STRING(s));
+#else
+        *sipCppPtr = new std::string(PyUnicode_AS_DATA(s));
+#endif
         Py_DECREF(s);
         return 1;
         }
+#if PY_MAJOR_VERSION < 3
         if (PyString_Check(sipPy)) {
         *sipCppPtr = new std::string(PyString_AS_STRING(sipPy));
             return 1;
         }
+#endif
     return 0;
 %End
 };


### PR DESCRIPTION
A simple check for newer LLVM versions that handles the legacy function name.