### PR TITLE
fixed function user data leak

### DIFF
--- a/src/SeExpr/ExprFuncX.cpp
+++ b/src/SeExpr/ExprFuncX.cpp
@@ -75,7 +75,9 @@ int ExprFuncSimple::buildInterpreter(const ExprFuncNode *node, Interpreter *inte
     int *opCurr = (&interpreter->opData[0]) + interpreter->ops[pc].second;
 
     ArgHandle args(opCurr, &interpreter->d[0], &interpreter->s[0], interpreter->callStack);
-    interpreter->s[ptrDataLoc] = reinterpret_cast<char *>(evalConstant(node, args));
+    ExprFuncNode::Data* data = evalConstant(node, args);
+    node->setData(data);
+    interpreter->s[ptrDataLoc] = reinterpret_cast<char *>(data);
 
     return outoperand;
 }
@@ -121,6 +123,7 @@ void SeExpr2LLVMEvalCustomFunction(int *opDataArg,
     if (!*funcdata) {
         handle.data = funcSimple->evalConstant(node, handle);
         *funcdata = reinterpret_cast<void *>(handle.data);
+        node->setData(handle.data);
     } else {
         handle.data = reinterpret_cast<SeExpr2::ExprFuncNode::Data *>(*funcdata);
     }

--- a/src/SeExpr/ExprNode.h
+++ b/src/SeExpr/ExprNode.h
@@ -519,7 +519,9 @@ class ExprFuncNode : public ExprNode {
         expr->addFunc(name);
     }
     virtual ~ExprFuncNode() {
-        delete _data;
+        if (_cleanupData == true) {
+            delete _data;
+        }
     }
 
     virtual ExprType prep(bool wantScalar, ExprVarEnvBuilder& envBuilder);
@@ -574,8 +576,16 @@ class ExprFuncNode : public ExprNode {
         Examples would be tokenized values,
         sorted lists for binary searches in curve evaluation, etc. This should be done
         in ExprFuncX::prep().
+
+        If you're setting allocated data (through new only) then use cleanupData as
+        true so that the data will be correctly deleted when the node is destroyed.
+        By default cleanupData is false to prevent the node accidentally cleaning
+        things that it shouldn't.
     */
-    void setData(Data* data) const { _data = data; }
+    void setData(Data* data, bool cleanupData = false) const {
+        _data = data;
+        _cleanupData = cleanupData
+    }
 
     //! get associated blind data (returns 0 if none)
     /***
@@ -594,6 +604,7 @@ class ExprFuncNode : public ExprNode {
                                               //    mutable std::vector<double> _scalarArgs;
                                               //    mutable std::vector<Vec3d> _vecArgs;
     mutable std::vector<int> _promote;
+    mutable bool _cleanupData;
     mutable Data* _data;
 };
 

--- a/src/SeExpr/ExprNode.h
+++ b/src/SeExpr/ExprNode.h
@@ -584,7 +584,7 @@ class ExprFuncNode : public ExprNode {
     */
     void setData(Data* data, bool cleanupData = false) const {
         _data = data;
-        _cleanupData = cleanupData
+        _cleanupData = cleanupData;
     }
 
     //! get associated blind data (returns 0 if none)

--- a/src/SeExpr/ExprNode.h
+++ b/src/SeExpr/ExprNode.h
@@ -519,7 +519,7 @@ class ExprFuncNode : public ExprNode {
         expr->addFunc(name);
     }
     virtual ~ExprFuncNode() {
-        if (_cleanupData == true) {
+        if (_data != nullptr && _data->_cleanup == true) {
             delete _data;
         }
     }
@@ -566,7 +566,9 @@ class ExprFuncNode : public ExprNode {
 
     //! base class for custom instance data
     struct Data {
+        Data(bool cleanup = false) : _cleanup(cleanup) {}
         virtual ~Data() {}
+        bool _cleanup;
     };
 
     //! associate blind data with this node (subsequently owned by this object)
@@ -576,16 +578,8 @@ class ExprFuncNode : public ExprNode {
         Examples would be tokenized values,
         sorted lists for binary searches in curve evaluation, etc. This should be done
         in ExprFuncX::prep().
-
-        If you're setting allocated data (through new only) then use cleanupData as
-        true so that the data will be correctly deleted when the node is destroyed.
-        By default cleanupData is false to prevent the node accidentally cleaning
-        things that it shouldn't.
     */
-    void setData(Data* data, bool cleanupData = false) const {
-        _data = data;
-        _cleanupData = cleanupData;
-    }
+    void setData(Data* data) const { _data = data; }
 
     //! get associated blind data (returns 0 if none)
     /***
@@ -604,7 +598,6 @@ class ExprFuncNode : public ExprNode {
                                               //    mutable std::vector<double> _scalarArgs;
                                               //    mutable std::vector<Vec3d> _vecArgs;
     mutable std::vector<int> _promote;
-    mutable bool _cleanupData;
     mutable Data* _data;
 };
 

--- a/src/SeExpr/ExprNode.h
+++ b/src/SeExpr/ExprNode.h
@@ -518,7 +518,8 @@ class ExprFuncNode : public ExprNode {
         : ExprNode(expr), _name(name), _func(0), _localFunc(0), _data(0) {
         expr->addFunc(name);
     }
-    virtual ~ExprFuncNode() {/* TODO: fix delete _data;*/
+    virtual ~ExprFuncNode() {
+        delete _data;
     }
 
     virtual ExprType prep(bool wantScalar, ExprVarEnvBuilder& envBuilder);


### PR DESCRIPTION
Here is a proposition to fix user data leaks when returning new data in a `ExprFuncSimple::evalConstant` call.