### PR TITLE
Properly fixes Windows build

### DIFF
--- a/src/SeExpr/CMakeLists.txt
+++ b/src/SeExpr/CMakeLists.txt
@@ -79,9 +79,11 @@ endif()
 
 ## Make the SeExpr library with and without LLVM support
 file(GLOB llvm_cpp "*.cpp")
-add_library(SeExpr2 SHARED ${io_cpp} ${core_cpp} ${parser_cpp} ${llvm_cpp})
 if (NOT WIN32)
+    add_library(SeExpr2 SHARED ${io_cpp} ${core_cpp} ${parser_cpp} ${llvm_cpp})
     target_link_libraries(SeExpr2 "dl" "pthread")
+else()
+    add_library(SeExpr2 STATIC ${io_cpp} ${core_cpp} ${parser_cpp} ${llvm_cpp})
 endif()
 
 ## Install binary and includes

--- a/src/SeExpr/ExprNode.cpp
+++ b/src/SeExpr/ExprNode.cpp
@@ -18,6 +18,7 @@
 #ifndef MAKEDEPEND
 #include <math.h>
 #include <sstream>
+#include <algorithm>
 #endif
 #include "Vec.h"
 #include "ExprType.h"

--- a/src/SeExpr/Expression.cpp
+++ b/src/SeExpr/Expression.cpp
@@ -45,8 +45,13 @@ bool Expression::debugging = getenv("SE_EXPR_DEBUG") != 0;
 // And the environment variables SE_EXPR_DEBUG
 static Expression::EvaluationStrategy chooseDefaultEvaluationStrategy() {
     if (Expression::debugging) {
-        std::cerr << "SeExpr2 Debug Mode Enabled " << __VERSION__
-                  << std::endl;
+        std::cerr << "SeExpr2 Debug Mode Enabled " <<
+#if defined(WINDOWS)
+            _MSC_FULL_VER
+#else
+            __VERSION__
+#endif
+            << std::endl;
     }
 #ifdef SEEXPR_ENABLE_LLVM
     if (char* env = getenv("SE_EXPR_EVAL")) {

--- a/src/SeExpr/Interpreter.cpp
+++ b/src/SeExpr/Interpreter.cpp
@@ -17,9 +17,12 @@
 #include "ExprNode.h"
 #include "Interpreter.h"
 #include "VarBlock.h"
+#include "Platform.h"
 #include <iostream>
 #include <cstdio>
+#if !defined(WINDOWS)
 #include <dlfcn.h>
+#endif
 
 // TODO: optimize to write to location directly on a CondNode
 namespace SeExpr2 {
@@ -48,9 +51,11 @@ void Interpreter::eval(VarBlock* block, bool debug) {
 void Interpreter::print(int pc) const {
     std::cerr << "---- ops     ----------------------" << std::endl;
     for (size_t i = 0; i < ops.size(); i++) {
-        Dl_info info;
         const char* name = "";
+#if !defined(WINDOWS)
+        Dl_info info;
         if (dladdr((void*)ops[i].first, &info)) name = info.dli_sname;
+#endif
         fprintf(stderr, "%s %s %p (", pc == (int)i ? "-->" : "   ", name, ops[i].first);
         int nextGuy = (i == ops.size() - 1 ? opData.size() : ops[i + 1].second);
         for (int k = ops[i].second; k < nextGuy; k++) {

--- a/src/SeExpr/Interpreter.cpp
+++ b/src/SeExpr/Interpreter.cpp
@@ -20,6 +20,7 @@
 #include "Platform.h"
 #include <iostream>
 #include <cstdio>
+#include <algorithm>
 #if !defined(WINDOWS)
 #include <dlfcn.h>
 #endif

--- a/src/SeExpr/Noise.cpp
+++ b/src/SeExpr/Noise.cpp
@@ -96,7 +96,7 @@ T noiseHelper(const T* X, const int* period = 0) {
         weights[1][k] = weights[0][k] - 1;  // dist to cell with index one above
     }
     // compute function values propagated from zero from each node
-    int num = 1 << d;
+    const int num = 1 << d;
     T vals[num];
     for (int dummy = 0; dummy < num; dummy++) {
         int latticeIndex[d];

--- a/src/SeExpr/Platform.h
+++ b/src/SeExpr/Platform.h
@@ -51,6 +51,7 @@
 #include <string.h>
 #include <pthread.h>
 #include <inttypes.h>
+#include <sys/time.h>
 // OS for spinlock
 #ifdef __APPLE__
 #include <libkern/OSAtomic.h>
@@ -62,7 +63,6 @@
 #include <stdio.h>
 #include <math.h>
 #include <assert.h>
-#include <sys/time.h>
 
 // missing functions on Windows
 #ifdef WINDOWS
@@ -125,11 +125,33 @@ class Timer {
 };
 #else  // Windows
 class Timer {
-  public:
-    Timer() : started(false) {}
+    __int64 ticksPerSeconds;
+    __int64 startTime, stopTime;
+    bool started;
 
-    void start() { std::cerr << "timer not implemented on Windows" << std::endl; }
-    long elapsedTime() { return 0; }
+    __int64 time() {
+        LARGE_INTEGER perfCounter;
+        QueryPerformanceCounter(&perfCounter);
+        return perfCounter.QuadPart;
+    }
+
+  public:
+    Timer() : started(false) {
+        // get the timer frequency
+        LARGE_INTEGER frequency;
+        QueryPerformanceFrequency(&frequency);
+        ticksPerSeconds = frequency.QuadPart;
+    }
+
+    void start() {
+        started = true;
+        startTime = this->time();
+    }
+
+    long elapsedTime() {
+        stopTime = this->time();
+        return ((stopTime - startTime) * 1000000) / ticksPerSeconds;
+    }
 };
 #endif
 

--- a/src/SeExpr/Platform.h
+++ b/src/SeExpr/Platform.h
@@ -150,7 +150,7 @@ class Timer {
 
     long elapsedTime() {
         stopTime = this->time();
-        return ((stopTime - startTime) * 1000000) / ticksPerSeconds;
+        return static_cast<long>(((stopTime - startTime) * 1000000) / ticksPerSeconds);
     }
 };
 #endif
@@ -159,7 +159,8 @@ class PrintTiming {
   public:
     PrintTiming(const std::string& s) : _s(s) { _timer.start(); }
 
-    ~PrintTiming() { std::cout << _s << " (" << _timer.elapsedTime() << " ms)" << std::endl; }
+    ~PrintTiming() { std::cout << _s.c_str() << " (" << _timer.elapsedTime() << " ms)" << std::endl; }
+
 
   private:
     Timer _timer;

--- a/src/SeExpr/Vec.h
+++ b/src/SeExpr/Vec.h
@@ -20,6 +20,7 @@
 #include <cstdlib>
 #include <cmath>
 #include <iostream>
+#include "Platform.h"
 
 //#############################################################################
 // Template Metaprogramming Helpers
@@ -40,7 +41,11 @@ struct my_enable_if {
 };
 //! Enable_if failure case (substitution failure is not an error)
 template <class T>
-struct my_enable_if<false, T> {};
+struct my_enable_if<false, T> {
+#if defined(WINDOWS)
+    typedef T TYPE;
+#endif
+};
 
 //! Static conditional type true case
 template <bool c, class T1, class T2>

--- a/windows7/SeExpr/generated/ExprParser.cpp
+++ b/windows7/SeExpr/generated/ExprParser.cpp
@@ -1030,7 +1030,6 @@ while (SeExprYYID (0))
 
 /* Print *SeExprYYLOCP on SeExprYYO.  Private, do not rely on its existence. */
 
-__attribute__((__unused__))
 #if (defined __STDC__ || defined __C99__FUNC__ \
      || defined __cplusplus || defined _MSC_VER)
 static unsigned


### PR DESCRIPTION
Properly (kind of) fixed build on Windows. This PR doesn't modify Linux/MacOS behavior. It was tested with Visual Studio 2017. It seems to work fine, but there are a few things that I'm not really confident in:

- 693fdf5 I had to add a TYPE in the my_enable_if failure case. I think the whole point of it not having the TYPE definition *is* to fail to compile if accidently used, but I don't know how Gcc and MSVC handle those kind of template constructs...

- bba7589 On Windows, you can't link agaisnt a dll without exporting classes definitions to a .lib. Since that would require a lot of additional code (every "public" classes of the library would need to use the __declspec(dllexport) decorator) I decided to make the whole lib static on Windows.

As always, feel free to tell me if anything's wrong, if you'd prefer the lib to stay a dll on Windows, etc.

