### PR TITLE
Make Interpreter's evaluations thread safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@
 CMakeCache.txt
 src/SeExpr/parser
 src/SeExprEditor/generated
+.vs
+.vscode
+CMakeLists.txt.user
+CMakeSettings.json

--- a/src/SeExpr/Expression.cpp
+++ b/src/SeExpr/Expression.cpp
@@ -306,7 +306,7 @@ const double* Expression::evalFP(VarBlock* varBlock) const {
     if (_isValid) {
         if (_evaluationStrategy == UseInterpreter) {
             _interpreter->eval(varBlock);
-            return &_interpreter->d[_returnSlot];
+            return (varBlock && varBlock->threadSafe) ? &(varBlock->d[_returnSlot]) : &_interpreter->d[_returnSlot];
         } else {  // useLLVM
             return _llvmEvaluator->evalFP(varBlock);
         }
@@ -341,7 +341,7 @@ const char* Expression::evalStr(VarBlock* varBlock) const {
     if (_isValid) {
         if (_evaluationStrategy == UseInterpreter) {
             _interpreter->eval(varBlock);
-            return _interpreter->s[_returnSlot];
+            return (varBlock && varBlock->threadSafe) ? varBlock->s[_returnSlot] : _interpreter->s[_returnSlot];
         } else {  // useLLVM
             return _llvmEvaluator->evalStr(varBlock);
         }

--- a/src/SeExpr/Interpreter.cpp
+++ b/src/SeExpr/Interpreter.cpp
@@ -29,13 +29,30 @@
 namespace SeExpr2 {
 
 void Interpreter::eval(VarBlock* block, bool debug) {
+    // get pointers to the working data
+    double* fp = d.data();
+    char** str = s.data();
+
+    // if we have a VarBlock instance, we need to update the working data
     if (block) {
-        static_assert(sizeof(char*) == sizeof(size_t), "Expect to fit size_t in char*");
-        s[0] = reinterpret_cast<char*>(block->data());
-        s[1] = reinterpret_cast<char*>(block->indirectIndex);
+        // if the VarBlock is flagged as thread safe, copy the interpreter's data to it.
+        if (block->threadSafe == true) {
+            // copy double data
+            block->d.resize(d.size());
+            fp = block->d.data();
+            memcpy(fp, d.data(), d.size() * sizeof(double));
+
+            // copy string data
+            block->s.resize(s.size());
+            str = block->s.data();
+            memcpy(str, s.data(), s.size() * sizeof(char*));
+        }
+
+        // set the variable evaluation data
+        str[0] = reinterpret_cast<char*>(block->data());
+        str[1] = reinterpret_cast<char*>(block->indirectIndex);
     }
-    double* fp = &d[0];
-    char** str = &s[0];
+
     int pc = _pcStart;
     int end = ops.size();
     while (pc < end) {


### PR DESCRIPTION
Hi,

I've been playing with SeExpr in a multithreaded context, and I noticed that if you evaluate the same expression "v" in multiple threads, you get corrupted results, even if each thread is using a `VarBlock` instance.

The problem is that even though `VarBlock` holds input variables values and can hold the result of the evaluation, it doesn't hold the working data: `Interpreter::d`. This is where each op code writes its result. For instance, `EvalVarBlockIndirect` :

```c++
    double* destPointer = fp + destIndex;
    for (int i = 0; i < dim; i++) destPointer[i] = basePointer[i];
```

 `fp` is a pointer to the `Interpreter`'s `d` member. And this member is shared between all concurrent evalutions ...

Using the LLVM evaluator there is no problem, probably because the generated code works on the stack, and each evaluation creates its own stack.

Anyway, this pull request fixes the problem for the Interpreter by storing copies of the working data (namely the `d` and `s` members of `Interpreter` in the instance of `VarBlock` passed to the evaluation method.

If you have any question or remarks on the pull request, don't hesitate.