### PR TITLE
Don't build PyQt UI bindings if USE_PYTHON is False

### DIFF
--- a/src/SeExpr2/UI/CMakeLists.txt
+++ b/src/SeExpr2/UI/CMakeLists.txt
@@ -13,44 +13,10 @@
 # You may obtain a copy of the License at
 # http://www.apache.org/licenses/LICENSE-2.0
 
-# Find python includes and libs. cmake doesn't seem to handle automatically
-
-find_package(PythonInterp)
-find_package(PythonLibs)
-
-macro(get_build_info NAME STORAGE)
-    execute_process(
-        COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/src/build/build-info ${NAME}
-        OUTPUT_VARIABLE ${STORAGE}
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-endmacro()
-
-get_build_info(python-site PYTHON_SITE)
-get_build_info(python-inc PYTHON_INCLUDE_DIR)
-get_build_info(sip-inc SIP_INCLUDE_DIR)
-
 if (EXISTS "/usr/share/apps/cmake/modules")
     # Needed for some versions of CMake, which only look in version-specific module path
     list(APPEND CMAKE_MODULE_PATH "/usr/share/apps/cmake/modules")
 endif()
-
-if (NOT DEFINED PYQT_SIP_FLAGS)
-    if (ENABLE_QT5)
-        get_build_info(pyqt5-sip-flags PYQT_SIP_FLAGS)
-    else()
-        get_build_info(pyqt4-sip-flags PYQT_SIP_FLAGS)
-    endif()
-    separate_arguments(PYQT_SIP_FLAGS)
-endif()
-
-if (NOT DEFINED PYQT_SIP_DIR)
-    get_build_info(pyqt4-sip PYQT_SIP_DIR)
-    if (NOT DEFINED PYQT_SIP_DIR)
-       message(FATAL_ERROR "PYQT_SIP_DIR must be defined")
-    endif()
-endif()
-
-set(CMAKE_INSTALL_PYTHON "${PYTHON_SITE}/SeExpr2" )
 
 # Other package dependencies...
 find_package(OpenGL)
@@ -163,44 +129,79 @@ if (Qt5_FOUND OR QT4_FOUND)
     install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/ DESTINATION ${INCLUDE_DIR}/UI
             FILES_MATCHING PATTERN "*.h")
 
-    # Generate python module expreditor2, using sip
-    find_program(SIP_EXEC sip)
+    if(USE_PYTHON)
+        # Generate python module expreditor2, using sip
+        find_program(SIP_EXEC sip)
 
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-    include_directories(${SIP_INCLUDE_DIR}
-                        ${PYQT_SIP_DIR}
-                        ${PYTHON_INCLUDE_DIR})
+        # Find python includes and libs. cmake doesn't seem to handle automatically
+        find_package(PythonInterp)
+        find_package(PythonLibs)
 
-    add_custom_command(OUTPUT sipexpreditor2part0.cpp
-                       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/SeExpr2Editor.sip
-                       COMMENT 'Processing SeExpr2Editor.sip'
-                       COMMAND ${SIP_EXEC} -w -c .
-                       ${PYQT_SIP_FLAGS}
-                       -j 1
-                       -I. -I${PYQT_SIP_DIR} -I${SIP_INCLUDE_DIR}
-                       ${CMAKE_CURRENT_SOURCE_DIR}/SeExpr2Editor.sip
-                       VERBATIM)
+        macro(get_build_info NAME STORAGE)
+            execute_process(
+                COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/src/build/build-info ${NAME}
+                OUTPUT_VARIABLE ${STORAGE}
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+        endmacro()
 
-    add_library(expreditor2 SHARED sipexpreditor2part0.cpp)
-    target_link_libraries(expreditor2 SeExpr2Editor ${SEEXPR_LIBRARIES}
-                          ${OPENGL_LIBRARY} ${GLUT_LIBRARY} ${PYTHON_LIBRARIES})
+        get_build_info(python-site PYTHON_SITE)
+        get_build_info(python-inc PYTHON_INCLUDE_DIR)
+        get_build_info(sip-inc SIP_INCLUDE_DIR)
 
-    if (ENABLE_QT5)
-        target_link_libraries(expreditor2 SeExpr2Editor
-                              Qt5::Core
-                              Qt5::Gui
-                              Qt5::Widgets
-                              Qt5::OpenGL)
-    else()
-        target_link_libraries(expreditor2 SeExpr2Editor
-                              ${QT_QTCORE_LIBRARY}
-                              ${QT_QTGUI_LIBRARY}
-                              ${QT_QTOPENGL_LIBRARY})
+        if (NOT DEFINED PYQT_SIP_FLAGS)
+            if (ENABLE_QT5)
+                get_build_info(pyqt5-sip-flags PYQT_SIP_FLAGS)
+            else()
+                get_build_info(pyqt4-sip-flags PYQT_SIP_FLAGS)
+            endif()
+            separate_arguments(PYQT_SIP_FLAGS)
+        endif()
+
+        if (NOT DEFINED PYQT_SIP_DIR)
+            get_build_info(pyqt4-sip PYQT_SIP_DIR)
+            if (NOT DEFINED PYQT_SIP_DIR)
+               message(FATAL_ERROR "PYQT_SIP_DIR must be defined")
+            endif()
+        endif()
+
+        set(CMAKE_INSTALL_PYTHON "${PYTHON_SITE}/SeExpr2" )
+
+        set(CMAKE_CXX_FLAGS "-std=c++11")
+        include_directories(${SIP_INCLUDE_DIR}
+                            ${PYQT_SIP_DIR}
+                            ${PYTHON_INCLUDE_DIR})
+
+        add_custom_command(OUTPUT sipexpreditor2part0.cpp
+                           DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/SeExpr2Editor.sip
+                           COMMENT 'Processing SeExpr2Editor.sip'
+                           COMMAND ${SIP_EXEC} -w -c .
+                           ${PYQT_SIP_FLAGS}
+                           -j 1
+                           -I. -I${PYQT_SIP_DIR} -I${SIP_INCLUDE_DIR}
+                           ${CMAKE_CURRENT_SOURCE_DIR}/SeExpr2Editor.sip
+                           VERBATIM)
+
+        add_library(expreditor2 SHARED sipexpreditor2part0.cpp)
+        target_link_libraries(expreditor2 SeExpr2Editor ${SEEXPR_LIBRARIES}
+                              ${OPENGL_LIBRARY} ${GLUT_LIBRARY} ${PYTHON_LIBRARIES})
+
+        if (ENABLE_QT5)
+            target_link_libraries(expreditor2 SeExpr2Editor
+                                  Qt5::Core
+                                  Qt5::Gui
+                                  Qt5::Widgets
+                                  Qt5::OpenGL)
+        else()
+            target_link_libraries(expreditor2 SeExpr2Editor
+                                  ${QT_QTCORE_LIBRARY}
+                                  ${QT_QTGUI_LIBRARY}
+                                  ${QT_QTOPENGL_LIBRARY})
+        endif()
+
+        # No prefix on python module name
+        set_target_properties(expreditor2 PROPERTIES PREFIX "")
+        install(TARGETS expreditor2 DESTINATION ${CMAKE_INSTALL_PYTHON})
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py
+                DESTINATION ${CMAKE_INSTALL_PYTHON})
     endif()
-
-    # No prefix on python module name
-    set_target_properties(expreditor2 PROPERTIES PREFIX "")
-    install(TARGETS expreditor2 DESTINATION ${CMAKE_INSTALL_PYTHON})
-    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py
-            DESTINATION ${CMAKE_INSTALL_PYTHON})
 endif()


### PR DESCRIPTION
Reorganizes the UI build process so that `libSeExpr2Editor` can be built without the PyQt bindings when `USE_PYTHON` is off. Some facilities do not have (or use) PyQt internally, but may still wish to use the editor library in C++-based GUIs.

Eventually, it would be great to be able to build the core Python bindings but skip the `libSeExpr2Editor` PyQt bindings, so this is sort of an incremental step in that direction.