### PR TITLE
build related to LLVM on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ if (ENABLE_LLVM_BACKEND)
 
         set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${LLVM_DIR}")
         include(LLVM-Config)
+        include(LLVMConfig)
         include(HandleLLVMOptions)
 
         message(STATUS "LLVM_DEFINITIONS =" ${LLVM_DEFINITIONS})
@@ -152,16 +153,20 @@ if (ENABLE_LLVM_BACKEND)
         message(STATUS "LLVM_LIB = ${LLVM_LIB}")
 
         if (LLVM_VERSION VERSION_LESS 3.8.0)
-            set(ENABLE_LLVM_BACKEND false)
-            set(SEEXPR_ENABLE_LLVM_BACKEND false)
+            set(ENABLE_LLVM_BACKEND off)
             message(STATUS "Not building with LLVM, version must be >= 3.8.0")
         endif()
 
     else()
          set(ENABLE_LLVM_BACKEND off)
-         set(SEEXPR_ENABLE_LLVM_BACKEND 0)
     endif()
 endif()
+
+# If LLVM is not enabled, set the SEEXPR_ENABLE_LLVM_BACKEND to 0 to fully disable
+# LLVM stuff in the ExprConfig.h sources.
+if (NOT ENABLE_LLVM_BACKEND)
+     set(SEEXPR_ENABLE_LLVM_BACKEND 0)
+endif ()
 
 ## Setup platform specific helper defines build variants
 if (WIN32)


### PR DESCRIPTION
Hi,

There are still a few problems when building SeExpr, which this pull request fixes:

- The preprocessor SEEXPR_ENABLE_LLVM_BACKEND was not defined when the ENABLE_LLVM_BACKEND option was off, resulting in an invalid ExprConfig.h header. It's now set to 0 whenever ENABLE_LLVM_BACKEND is off.
- LLVMConfig.cmake wasn't included (it was previously included through a find_package, but commit 8ef62bb05ddc0439b006d4e3447967ba9aa05a73 kind of undid that :p) so on Windows the LLVM include and lib dirs were not defined (llvm-config doesn't exist here) So now I just include LLVMConfig.cmake alongside LLVM-Config.cmake.