### PR TITLE
fixed lots of warnings on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ endif()
 ## Setup platform specific helper defines build variants
 if (WIN32)
     add_definitions(-DSEEXPR_WIN32)
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 else()
     add_definitions(-Wall -Wextra -Wno-unused-parameter)
     add_definitions(-pthread)

--- a/src/SeExpr2/Curve.cpp
+++ b/src/SeExpr2/Curve.cpp
@@ -62,13 +62,13 @@ void Curve<T>::preparePoints() {
     // Setup boundary conditions on sentinel values
     CV& end = *(_cvData.end() - 1);
     CV& begin = *(_cvData.begin());
-    int realCVs = _cvData.size() - 2;
+    int realCVs = static_cast<int>(_cvData.size()) - 2;
     assert(realCVs >= 0);
     if (realCVs > 0) {
         begin._val = _cvData[1]._val;
         begin._deriv = T();
         begin._interp = kNone;
-        int lastIndex = _cvData.size() - 1;
+        int lastIndex = static_cast<int>(_cvData.size()) - 1;
         end._val = _cvData[lastIndex - 1]._val;
         end._deriv = T();
         end._interp = kNone;
@@ -104,16 +104,16 @@ template <class T>
 T Curve<T>::getValue(const double param) const {
     assert(prepared);
     // find the cv data point index just greater than the desired param
-    const int numPoints = _cvData.size();
+    const int numPoints = static_cast<int>(_cvData.size());
     const CV* cvDataBegin = &_cvData[0];
     int index =
-        std::upper_bound(cvDataBegin, cvDataBegin + numPoints, CV(param, T(), kLinear), cvLessThan) - cvDataBegin;
+        static_cast<int>(std::upper_bound(cvDataBegin, cvDataBegin + numPoints, CV(param, T(), kLinear), cvLessThan) - cvDataBegin);
     index = std::max(1, std::min(index, numPoints - 1));
 
-    const float t0 = _cvData[index - 1]._pos;
+    const float t0 = static_cast<float>(_cvData[index - 1]._pos);
     const T k0 = _cvData[index - 1]._val;
     const InterpType interp = _cvData[index - 1]._interp;
-    const float t1 = _cvData[index]._pos;
+    const float t1 = static_cast<float>(_cvData[index]._pos);
     const T k1 = _cvData[index]._val;
     switch (interp) {
         case kNone:
@@ -150,16 +150,16 @@ template <class T>
 double Curve<T>::getChannelValue(const double param, int channel) const {
     assert(prepared);
     // find the cv data point index just greater than the desired param
-    const int numPoints = _cvData.size();
+    const int numPoints = static_cast<int>(_cvData.size());
     const CV* cvDataBegin = &_cvData[0];
     int index =
-        std::upper_bound(cvDataBegin, cvDataBegin + numPoints, CV(param, T(), kLinear), cvLessThan) - cvDataBegin;
+        static_cast<int>(std::upper_bound(cvDataBegin, cvDataBegin + numPoints, CV(param, T(), kLinear), cvLessThan) - cvDataBegin);
     index = std::max(1, std::min(index, numPoints - 1));
 
-    const float t0 = _cvData[index - 1]._pos;
+    const float t0 = static_cast<float>(_cvData[index - 1]._pos);
     const double k0 = comp(_cvData[index - 1]._val, channel);
     const InterpType interp = _cvData[index - 1]._interp;
-    const float t1 = _cvData[index]._pos;
+    const float t1 = static_cast<float>(_cvData[index]._pos);
     const double k1 = comp(_cvData[index]._val, channel);
     switch (interp) {
         case kNone:
@@ -199,9 +199,9 @@ template <class T>
 typename Curve<T>::CV Curve<T>::getLowerBoundCV(const double param) const {
     assert(prepared);
     const CV* cvDataBegin = &_cvData[0];
-    int numPoints = _cvData.size();
+    int numPoints = static_cast<int>(_cvData.size());
     int index =
-        std::upper_bound(cvDataBegin, cvDataBegin + numPoints, CV(param, T(), kLinear), cvLessThan) - cvDataBegin;
+        static_cast<int>(std::upper_bound(cvDataBegin, cvDataBegin + numPoints, CV(param, T(), kLinear), cvLessThan) - cvDataBegin);
     index = std::max(1, std::min(index, numPoints - 1));
     if (index - 1 > 0) return _cvData[index - 1];
     return _cvData[index];

--- a/src/SeExpr2/ExprBuiltins.cpp
+++ b/src/SeExpr2/ExprBuiltins.cpp
@@ -266,7 +266,7 @@ Vec3d midhsi(int n, const Vec3d* args) {
 
         // scale hsi values according to mask (both directions)
         h *= m;
-        float absm = fabs(m);
+        float absm = fabs(static_cast<float>(m));
         s = s * absm + 1 - absm;
         i = i * absm + 1 - absm;
         if (m < 0) {
@@ -671,7 +671,7 @@ double fbm4(int n, const Vec3d* args) {
         case 3:
             octaves = int(clamp(args[2][0], 1, 8));
         case 2:
-            time = args[1][0];
+            time = static_cast<float>(args[1][0]);
         case 1:
             p = args[0];
     }
@@ -706,7 +706,7 @@ Vec3d vfbm4(int n, const Vec3d* args) {
         case 3:
             octaves = int(clamp(args[2][0], 1, 8));
         case 2:
-            time = args[1][0];
+            time = static_cast<float>(args[1][0]);
         case 1:
             p = args[0];
     }
@@ -885,7 +885,7 @@ Vec3d voronoiFn(VoronoiPointData& data, int n, const Vec3d* args) {
         case 4:
             return f2 - f1;
         case 5: {
-            float scalefactor = (pos2 - pos1).length() / ((pos1 - p).length() + (pos2 - p).length());
+            float scalefactor = static_cast<float>((pos2 - pos1).length() / ((pos1 - p).length() + (pos2 - p).length()));
             return smoothstep(f2 - f1, 0, 0.1 * scalefactor);
         }
     }
@@ -952,7 +952,7 @@ Vec3d cvoronoiFn(VoronoiPointData& data, int n, const Vec3d* args) {
         case 4:
             return (f2 - f1) * color;
         case 5: {
-            float scalefactor = (pos2 - pos1).length() / ((pos1 - p).length() + (pos2 - p).length());
+            float scalefactor = static_cast<float>((pos2 - pos1).length() / ((pos1 - p).length() + (pos2 - p).length()));
             return smoothstep(f2 - f1, 0, 0.1 * scalefactor) * color;
         }
     }
@@ -1110,7 +1110,7 @@ Vec3d rotate(int n, const Vec3d* args) {
     if (n != 3) return 0.0;
     const Vec3d& P = args[0];
     const Vec3d& axis = args[1];
-    float angle = args[2][0];
+    float angle = static_cast<float>(args[2][0]);
     double len = axis.length();
     if (!len) return P;
     return P.rotateBy(axis / len, angle);
@@ -1500,16 +1500,16 @@ class PrintFuncX : public ExprFuncSimple {
                 delete data;
                 assert(false);
             } else if (format[percentStart + 1] == '%') {
-                searchStart = percentStart + 2;
+                searchStart = static_cast<int>(percentStart + 2);
                 continue;
             } else if (format[percentStart + 1] == 'v' || format[percentStart + 1] == 'f') {
                 char c = format[percentStart + 1];
                 int code = (c == 'v') ? -1 : -2;
                 needed++;
-                if (bakeStart != percentStart) ranges.push_back(std::pair<int, int>(bakeStart, percentStart));
+                if (bakeStart != percentStart) ranges.push_back(std::pair<int, int>(bakeStart, static_cast<int>(percentStart)));
                 ranges.push_back(std::pair<int, int>(code, code));
                 items++;
-                searchStart = percentStart + 2;
+                searchStart = static_cast<int>(percentStart + 2);
                 bakeStart = searchStart;
             } else {
                 // node->addError("Invalid format string, only %v is allowed");
@@ -1520,7 +1520,7 @@ class PrintFuncX : public ExprFuncSimple {
                 assert(false);
             }
         }
-        if (bakeStart != format.length()) ranges.push_back(std::pair<int, int>(bakeStart, format.length()));
+        if (bakeStart != format.length()) ranges.push_back(std::pair<int, int>(bakeStart, static_cast<int>(format.length())));
 
         if (items != args.nargs() - 1) {
             // node->addError("Wrong number of arguments for format string");

--- a/src/SeExpr2/ExprFuncStandard.cpp
+++ b/src/SeExpr2/ExprFuncStandard.cpp
@@ -206,7 +206,7 @@ int ExprFuncStandard::buildInterpreter(const ExprFuncNode* node, Interpreter* in
         for (int k = 0; k < node->type().dim(); k++) {
             interpreter->addOp(op);
             interpreter->addOperand(funcPtrLoc);
-            if (_funcType == FUNCN) interpreter->addOperand(argOps.size());
+            if (_funcType == FUNCN) interpreter->addOperand(static_cast<int>(argOps.size()));
             for (size_t c = 0; c < argOps.size(); c++) {
                 if (node->child(c)->type().isFP(1))
                     interpreter->addOperand(argOps[c]);
@@ -231,7 +231,7 @@ int ExprFuncStandard::buildInterpreter(const ExprFuncNode* node, Interpreter* in
 
         interpreter->addOp(op);
         interpreter->addOperand(funcPtrLoc);
-        if (_funcType == FUNCNV || _funcType == FUNCNVV) interpreter->addOperand(argOps.size());
+        if (_funcType == FUNCNV || _funcType == FUNCNVV) interpreter->addOperand(static_cast<int>(argOps.size()));
         for (size_t c = 0; c < argOps.size(); c++) {
             interpreter->addOperand(argOps[c]);
         }

--- a/src/SeExpr2/ExprMultiExpr.cpp
+++ b/src/SeExpr2/ExprMultiExpr.cpp
@@ -169,7 +169,7 @@ ExprHandle Expressions::addExpression(const std::string &varName, ExprType seTy,
 
 VariableSetHandle Expressions::getLoopVarSetHandle(VariableHandle vh) {
     GlobalVal *thisvar = *vh;
-    unsigned initSize = thisvar->users.size();
+    unsigned initSize = static_cast<unsigned>(thisvar->users.size());
     if (!initSize) return AllExternalVars.end();
 
     std::set<DExpression *> ret = getAffectedExpr(thisvar);

--- a/src/SeExpr2/ExprNode.h
+++ b/src/SeExpr2/ExprNode.h
@@ -111,7 +111,7 @@ class ExprNode {
     /// Access parent node - root node has no parent
     const ExprNode* parent() const { return _parent; }
     /// Number of children
-    int numChildren() const { return _children.size(); }
+    int numChildren() const { return static_cast<int>(_children.size()); }
 
     /// Get 0 indexed child
     const ExprNode* child(size_t i) const { return _children[i]; }

--- a/src/SeExpr2/Expression.cpp
+++ b/src/SeExpr2/Expression.cpp
@@ -269,15 +269,15 @@ void Expression::prep() const {
         const char* start = _expression.c_str();
         const char* p = _expression.c_str();
         while (*p != 0) {
-            if (*p == '\n') lines.push_back(p - start);
+            if (*p == '\n') lines.push_back(static_cast<int>(p - start));
             p++;
         }
-        lines.push_back(p - start);
+        lines.push_back(static_cast<int>(p - start));
 
         std::stringstream sstream;
         for (unsigned int i = 0; i < _errors.size(); i++) {
             int* bound = std::lower_bound(&*lines.begin(), &*lines.end(), _errors[i].startPos);
-            int line = bound - &*lines.begin() + 1;
+            int line = static_cast<int>(bound - &*lines.begin() + 1);
             int lineStart = line == 1 ? 0 : lines[line - 1];
             int col = _errors[i].startPos - lineStart;
             sstream << "  Line " << line << " Col " << col << " - " << _errors[i].error << std::endl;
@@ -324,7 +324,7 @@ void Expression::evalMultiple(VarBlock* varBlock, int outputVarBlockOffset, size
             // double* iHack=reinterpret_cast<double**>(varBlock->data())[outputVarBlockOffset];
             double* destBase = reinterpret_cast<double**>(varBlock->data())[outputVarBlockOffset];
             for (size_t i = rangeStart; i < rangeEnd; i++) {
-                varBlock->indirectIndex = i;
+                varBlock->indirectIndex = static_cast<int>(i);
                 const double* f = evalFP(varBlock);
                 for (int k = 0; k < dim; k++) {
                     destBase[dim * i + k] = f[k];

--- a/src/SeExpr2/Interpreter.cpp
+++ b/src/SeExpr2/Interpreter.cpp
@@ -50,11 +50,11 @@ void Interpreter::eval(VarBlock* block, bool debug) {
 
         // set the variable evaluation data
         str[0] = reinterpret_cast<char*>(block->data());
-        str[1] = reinterpret_cast<char*>(block->indirectIndex);
+        str[1] = reinterpret_cast<char*>(static_cast<size_t>(block->indirectIndex));
     }
 
     int pc = _pcStart;
-    int end = ops.size();
+    int end = static_cast<int>(ops.size());
     while (pc < end) {
         if (debug) {
             std::cerr << "Running op at " << pc << std::endl;
@@ -75,7 +75,7 @@ void Interpreter::print(int pc) const {
         if (dladdr((void*)ops[i].first, &info)) name = info.dli_sname;
 #endif
         fprintf(stderr, "%s %s %p (", pc == (int)i ? "-->" : "   ", name, ops[i].first);
-        int nextGuy = (i == ops.size() - 1 ? opData.size() : ops[i + 1].second);
+        int nextGuy = (i == ops.size() - 1 ? static_cast<int>(opData.size()) : ops[i + 1].second);
         for (int k = ops[i].second; k < nextGuy; k++) {
             fprintf(stderr, " %d", opData[k]);
         }
@@ -162,8 +162,8 @@ struct BinaryStringOp {
         // delete previous data and allocate a new buffer, only if needed
         // NOTE: this is more efficient, but might consume more memory...
         // Maybe make this behaviour configurable ?
-        int len1 = strlen(in1);
-        int len2 = strlen(in2);
+        int len1 = static_cast<int>(strlen(in1));
+        int len2 = static_cast<int>(strlen(in2));
         if (out == 0 || len1 + len2 + 1 > strlen(out))
         {
             delete [] out;

--- a/src/SeExpr2/Interpreter.h
+++ b/src/SeExpr2/Interpreter.h
@@ -67,7 +67,7 @@ class Interpreter {
     }
 
     /// Return the position that the next instruction will be placed at
-    int nextPC() { return ops.size(); }
+    int nextPC() { return static_cast<int>(ops.size()); }
 
     ///! adds an operator to the program (pointing to the data at the current location)
     int addOp(OpF op) {
@@ -75,8 +75,8 @@ class Interpreter {
             assert(false && "addOp called within another addOp");
         }
         _startedOp = true;
-        int pc = ops.size();
-        ops.push_back(std::make_pair(op, opData.size()));
+        int pc = static_cast<int>(ops.size());
+        ops.push_back(std::make_pair(op, static_cast<int>(opData.size())));
         return pc;
     }
 
@@ -85,7 +85,7 @@ class Interpreter {
         if (execute) {
             double* fp = &d[0];
             char** str = &s[0];
-            int pc = ops.size() - 1;
+            int pc = static_cast<int>(ops.size()) - 1;
             const std::pair<OpF, int>& op = ops[pc];
             int* opCurr = &opData[0] + op.second;
             pc += op.first(opCurr, fp, str, callStack);
@@ -95,21 +95,21 @@ class Interpreter {
     ///! Adds an operand. Note this should be done after doing the addOp!
     int addOperand(int param) {
         assert(_startedOp);
-        int ret = opData.size();
+        int ret = static_cast<int>(opData.size());
         opData.push_back(param);
         return ret;
     }
 
     ///! Allocate a floating point set of data of dimension n
     int allocFP(int n) {
-        int ret = d.size();
+        int ret = static_cast<int>(d.size());
         for (int k = 0; k < n; k++) d.push_back(0);
         return ret;
     }
 
     /// Allocate a pointer location (can be anything, but typically space for char*)
     int allocPtr() {
-        int ret = s.size();
+        int ret = static_cast<int>(s.size());
         s.push_back(0);
         return ret;
     }


### PR DESCRIPTION
When building on Windows, there were lots of warnings related to implicit type conversions + some warnings about non-secure calls (such as getenv)

This commit fixes those warnings, at least for the main SeExpr2 library.