### PR TITLE
fixed Vec on Windows (second go...)

### DIFF
--- a/src/SeExpr2/Vec.h
+++ b/src/SeExpr2/Vec.h
@@ -22,6 +22,13 @@
 #include <iostream>
 #include "Platform.h"
 
+// To fix differences in template TYPENAME resolution between MSVC and other compilers
+#if defined(WINDOWS)
+#   define TYPENAME
+#else
+#   define TYPENAME typename
+#endif
+
 //#############################################################################
 // Template Metaprogramming Helpers
 namespace SeExpr2 {
@@ -43,7 +50,7 @@ struct my_enable_if {
 template <class T>
 struct my_enable_if<false, T> {
 #if defined(WINDOWS)
-    typedef T TYPE;
+    typedef void TYPE;
 #endif
 };
 
@@ -105,29 +112,29 @@ class Vec {
     template <class T2>
     static Vec<T, d, false> copy(T2* raw,
                                  INVALID_WITH_VECTOR_REFERENCE u =
-                                     (typename my_enable_if<!ref, INVALID_WITH_VECTOR_REFERENCE>::TYPE())) {
+                                     (TYPENAME my_enable_if<!ref, INVALID_WITH_VECTOR_REFERENCE>::TYPE())) {
         Vec<T, d, false> ret;
         for (int k = 0; k < d; k++) ret[k] = static_cast<T>(raw[k]);
         return ret;
     }
 
     //! Initialize vector to be reference to plain raw data
-    explicit Vec(T* raw, INVALID_WITH_VECTOR_VALUE u = (typename my_enable_if<ref, INVALID_WITH_VECTOR_VALUE>::TYPE()))
+    explicit Vec(T* raw, INVALID_WITH_VECTOR_VALUE u = (TYPENAME my_enable_if<ref, INVALID_WITH_VECTOR_VALUE>::TYPE()))
         : x(raw) {}
 
     //! Empty constructor (this is invalid for a reference type)
-    Vec(INVALID_WITH_VECTOR_REFERENCE u = (typename my_enable_if<!ref, INVALID_WITH_VECTOR_REFERENCE>::TYPE())) {}
+    Vec(INVALID_WITH_VECTOR_REFERENCE u = (TYPENAME my_enable_if<!ref, INVALID_WITH_VECTOR_REFERENCE>::TYPE())) {}
 
     //! Convenience constant vector initialization (valid for any d)
-    Vec(T v0, INVALID_WITH_VECTOR_REFERENCE u = (typename my_enable_if<!ref, INVALID_WITH_VECTOR_REFERENCE>::TYPE())) {
+    Vec(T v0, INVALID_WITH_VECTOR_REFERENCE u = (TYPENAME my_enable_if<!ref, INVALID_WITH_VECTOR_REFERENCE>::TYPE())) {
         for (int k = 0; k < d; k++) x[k] = v0;
     }
 
     //! Convenience 2 vector initialization (only for d==2)
     Vec(T v1,
         T v2,
-        INVALID_WITH_VECTOR_REFERENCE u = (typename my_enable_if<!ref, INVALID_WITH_VECTOR_REFERENCE>::TYPE())) {
-        typename seexpr_static_assert<d == 2, INVALID_WITH_DIMENSION>::TYPE();
+        INVALID_WITH_VECTOR_REFERENCE u = (TYPENAME my_enable_if<!ref, INVALID_WITH_VECTOR_REFERENCE>::TYPE())) {
+        TYPENAME seexpr_static_assert<d == 2, INVALID_WITH_DIMENSION>::TYPE();
         x[0] = v1;
         x[1] = v2;
     }
@@ -136,8 +143,8 @@ class Vec {
     Vec(T v1,
         T v2,
         T v3,
-        INVALID_WITH_VECTOR_REFERENCE u = (typename my_enable_if<!ref, INVALID_WITH_VECTOR_REFERENCE>::TYPE())) {
-        typename seexpr_static_assert<d == 3, INVALID_WITH_DIMENSION>::TYPE();
+        INVALID_WITH_VECTOR_REFERENCE u = (TYPENAME my_enable_if<!ref, INVALID_WITH_VECTOR_REFERENCE>::TYPE())) {
+        TYPENAME seexpr_static_assert<d == 3, INVALID_WITH_DIMENSION>::TYPE();
         x[0] = v1;
         x[1] = v2;
         x[2] = v3;
@@ -148,8 +155,8 @@ class Vec {
         T v2,
         T v3,
         T v4,
-        INVALID_WITH_VECTOR_REFERENCE u = (typename my_enable_if<!ref, INVALID_WITH_VECTOR_REFERENCE>::TYPE())) {
-        typename seexpr_static_assert<d == 4, INVALID_WITH_DIMENSION>::TYPE();
+        INVALID_WITH_VECTOR_REFERENCE u = (TYPENAME my_enable_if<!ref, INVALID_WITH_VECTOR_REFERENCE>::TYPE())) {
+        TYPENAME seexpr_static_assert<d == 4, INVALID_WITH_DIMENSION>::TYPE();
         x[0] = v1;
         x[1] = v2;
         x[2] = v3;
@@ -159,13 +166,13 @@ class Vec {
     // for value it copies
     //! Copy construct. Only valid if we are not going to be a reference data!
     // Vec(const Vec&)
-    //{typename static_assert<!ref,INVALID_WITH_VECTOR_REFERENCE>::TYPE();}
+    //{TYPENAME static_assert<!ref,INVALID_WITH_VECTOR_REFERENCE>::TYPE();}
 
     //! Copy construct. Only valid if we are not going to be reference data!
     template <class T2, bool refother>
     Vec(const Vec<T2, d, refother>& other,
         INVALID_WITH_VECTOR_REFERENCE u =
-            (typename my_enable_if<!ref && refother != ref, INVALID_WITH_VECTOR_REFERENCE>::TYPE())) {
+            (TYPENAME my_enable_if<!ref && refother != ref, INVALID_WITH_VECTOR_REFERENCE>::TYPE())) {
         *this = other;
     }
 
@@ -329,13 +336,13 @@ class Vec {
     /** Cross product. */
     template <bool refother>
     T_VEC_VALUE cross(const Vec<T, 3, refother>& o) const {
-        typename seexpr_static_assert<d == 3, INVALID_WITH_DIMENSION>::TYPE();
+        TYPENAME seexpr_static_assert<d == 3, INVALID_WITH_DIMENSION>::TYPE();
         return T_VEC_VALUE(x[1] * o[2] - x[2] * o[1], x[2] * o[0] - x[0] * o[2], x[0] * o[1] - x[1] * o[0]);
     }
 
     /** Return a vector orthogonal to the current vector. */
     T_VEC_VALUE orthogonal() const {
-        typename seexpr_static_assert<d == 3, INVALID_WITH_DIMENSION>::TYPE();
+        TYPENAME seexpr_static_assert<d == 3, INVALID_WITH_DIMENSION>::TYPE();
         return T_VEC_VALUE(x[1] + x[2], x[2] - x[0], -x[0] - x[1]);
     }
 
@@ -345,7 +352,7 @@ class Vec {
      */
     template <bool refother>
     T angle(const Vec<T, 3, refother>& o) const {
-        typename seexpr_static_assert<d == 3, INVALID_WITH_DIMENSION>::TYPE();
+        TYPENAME seexpr_static_assert<d == 3, INVALID_WITH_DIMENSION>::TYPE();
         T l = length() * o.length();
         if (l == 0) return 0;
         return acos(dot(o) / l);
@@ -357,7 +364,7 @@ class Vec {
      */
     template <bool refother>
     T_VEC_VALUE rotateBy(const Vec<T, 3, refother>& axis, T angle) const {
-        typename seexpr_static_assert<d == 3, INVALID_WITH_DIMENSION>::TYPE();
+        TYPENAME seexpr_static_assert<d == 3, INVALID_WITH_DIMENSION>::TYPE();
         double c = cos(angle), s = sin(angle);
         return c * (*this) + (1 - c) * dot(axis) * axis - s * cross(axis);
     }


### PR DESCRIPTION
- remove typename from static type checks, MSVC doesn't like those and fails
- the fail case of my_enable_if now correctly catches errors at compile time also on Windows

note: tested with Visual Studio 12 (2013) up to the last version, and the changelist doesn't modify the behavior of the other compilers. I also made sure that static type checks were working correctly now

note2: my previous fix (693fdf52ffbddbd7faa15c260335db1986f7935a) doesn't seem to be sufficient anymore, and anyway it fixed compilation, but the static type checks didn't work properly, which is now fixed.

if you have any question/remark, don't hesitate !