### PR TITLE
fixed a crash when using string with binary and comparison operators …

### DIFF
--- a/src/SeExpr2/Interpreter.cpp
+++ b/src/SeExpr2/Interpreter.cpp
@@ -446,7 +446,7 @@ struct StrCompareEqOp {
                 fp[opData[2]] = strcmp(c[opData[0]], c[opData[1]]) == 0;
                 break;
             case '!':
-                fp[opData[2]] = strcmp(c[opData[0]], c[opData[1]]) == 0;
+                fp[opData[2]] = strcmp(c[opData[0]], c[opData[1]]) != 0;
                 break;
         }
         return 1;
@@ -756,7 +756,7 @@ int ExprAssignNode::buildInterpreter(Interpreter* interpreter) const {
     }
     interpreter->addOperand(op0);
     interpreter->addOperand(loc);
-    interpreter->endOp();
+    interpreter->endOp(child0Type.isString() == false);
     return loc;
 }
 
@@ -973,7 +973,7 @@ int ExprCompareEqNode::buildInterpreter(Interpreter* interpreter) const {
     interpreter->addOperand(op0);
     interpreter->addOperand(op1);
     interpreter->addOperand(op2);
-    interpreter->endOp();
+    interpreter->endOp(child0->type().isString() == false);
     return op2;
 }
 

--- a/src/tests/string.cpp
+++ b/src/tests/string.cpp
@@ -152,4 +152,16 @@ TEST(StringTests, BinaryOp) {
     EXPECT_TRUE(expr4.returnType().isString() == true);
     EXPECT_TRUE(expr4.isConstant() == false);
     EXPECT_STREQ(expr4.evalStr(), "a/b/c/d");
+
+    StringExpression expr5("v = 'o' + 'k';\nif ('fo' + 'o' != 'foo') {\n    v = 'error';\n}\nv");
+    EXPECT_TRUE(expr5.isValid() == true);
+    EXPECT_TRUE(expr5.returnType().isString() == true);
+    EXPECT_TRUE(expr5.isConstant() == true);
+    EXPECT_STREQ(expr5.evalStr(), "ok");
+
+    StringExpression expr6("v = 'err' + 'or';\nif ('fo' + 'o' == 'foo') {\n    v = 'ok';\n}\nv");
+    EXPECT_TRUE(expr6.isValid() == true);
+    EXPECT_TRUE(expr6.returnType().isString() == true);
+    EXPECT_TRUE(expr6.isConstant() == true);
+    EXPECT_STREQ(expr6.evalStr(), "ok");
 }


### PR DESCRIPTION
…and fixed incorrect inequlity operator for strings.

I also added 2 tests that were leading to crashes before the fixes. I couldn't run the test though since I'm on Windows, and I can't get them to run (I had a lot of tweaks to do to make them compile, but it still didn't run so I'll probably try again later and submit another pull request when everything works)

If you have any comment, feel free to share !