### PR TITLE
string nodes's special characters unescaping in the interpreter

### DIFF
--- a/src/SeExpr2/ExprLLVMCodeGeneration.cpp
+++ b/src/SeExpr2/ExprLLVMCodeGeneration.cpp
@@ -22,6 +22,7 @@
 #include "ExprNode.h"
 #include "ExprFunc.h"
 #include "VarBlock.h"
+#include "StringUtils.h"
 #include <array>
 using namespace llvm;
 using namespace SeExpr2;
@@ -1010,7 +1011,9 @@ LLVM_VALUE ExprPrototypeNode::codegen(LLVM_BUILDER Builder) LLVM_BODY {
     return F;
 }
 
-LLVM_VALUE ExprStrNode::codegen(LLVM_BUILDER Builder) LLVM_BODY { return Builder.CreateGlobalStringPtr(_str); }
+LLVM_VALUE ExprStrNode::codegen(LLVM_BUILDER Builder) LLVM_BODY {
+    return Builder.CreateGlobalStringPtr(unescapeString(_str));
+}
 
 LLVM_VALUE ExprSubscriptNode::codegen(LLVM_BUILDER Builder) LLVM_BODY {
     LLVM_VALUE op1 = child(0)->codegen(Builder);

--- a/src/SeExpr2/ExprNode.cpp
+++ b/src/SeExpr2/ExprNode.cpp
@@ -521,6 +521,35 @@ ExprType ExprNumNode::prep(bool wantScalar, ExprVarEnvBuilder& envBuilder) {
     return _type;
 }
 
+ExprStrNode::ExprStrNode(const Expression* expr, const char* str)  : ExprNode(expr), _str(str) {
+    // unescape a few common special characters
+    int index = 0;
+    bool special = false;
+    for (char c : _str) {
+        if (c == '\\') {
+            special = true;
+        } else {
+            if (special == true) {
+                special = false;
+                switch (c) {
+                    case 'n':   _str[index++] = '\n'; break;
+                    case 'r':   _str[index++] = '\r'; break;
+                    case 't':   _str[index++] = '\t'; break;
+                    case '\\':  _str[index++] = '\\'; break;
+                    case '"':   _str[index++] = '\"'; break;
+                    default:
+                        // leave the escape sequence as it was. We should probably issue a warning or something though.
+                        _str[index++] = '\\';
+                        _str[index++] = c;
+                }
+            } else {
+                _str[index++] = c;
+            }
+        }
+    }
+    _str.resize(index);
+}
+
 ExprType ExprStrNode::prep(bool wantScalar, ExprVarEnvBuilder& envBuilder) {
     _type = ExprType().String().Constant();
     return _type;

--- a/src/SeExpr2/ExprNode.cpp
+++ b/src/SeExpr2/ExprNode.cpp
@@ -27,6 +27,7 @@
 #include "ExprNode.h"
 #include "ExprFunc.h"
 #include "VarBlock.h"
+#include "StringUtils.h"
 
 // TODO: add and other binary op demote to scalar if wantScalar
 // TODO: logical operations like foo<bar should they do vector returns... right now no... implicit demote
@@ -521,33 +522,7 @@ ExprType ExprNumNode::prep(bool wantScalar, ExprVarEnvBuilder& envBuilder) {
     return _type;
 }
 
-ExprStrNode::ExprStrNode(const Expression* expr, const char* str)  : ExprNode(expr), _str(str) {
-    // unescape a few common special characters
-    int index = 0;
-    bool special = false;
-    for (char c : _str) {
-        if (c == '\\') {
-            special = true;
-        } else {
-            if (special == true) {
-                special = false;
-                switch (c) {
-                    case 'n':   _str[index++] = '\n'; break;
-                    case 'r':   _str[index++] = '\r'; break;
-                    case 't':   _str[index++] = '\t'; break;
-                    case '\\':  _str[index++] = '\\'; break;
-                    case '"':   _str[index++] = '\"'; break;
-                    default:
-                        // leave the escape sequence as it was. We should probably issue a warning or something though.
-                        _str[index++] = '\\';
-                        _str[index++] = c;
-                }
-            } else {
-                _str[index++] = c;
-            }
-        }
-    }
-    _str.resize(index);
+ExprStrNode::ExprStrNode(const Expression* expr, const char* str)  : ExprNode(expr), _str(unescapeString(str)) {
 }
 
 ExprType ExprStrNode::prep(bool wantScalar, ExprVarEnvBuilder& envBuilder) {

--- a/src/SeExpr2/ExprNode.h
+++ b/src/SeExpr2/ExprNode.h
@@ -501,7 +501,7 @@ class ExprNumNode : public ExprNode {
 /// Node that stores a string
 class ExprStrNode : public ExprNode {
   public:
-    ExprStrNode(const Expression* expr, const char* str) : ExprNode(expr), _str(str) {}
+    ExprStrNode(const Expression* expr, const char* str);
 
     virtual ExprType prep(bool wantScalar, ExprVarEnvBuilder& envBuilder);
     virtual int buildInterpreter(Interpreter* interpreter) const;

--- a/src/SeExpr2/StringUtils.h
+++ b/src/SeExpr2/StringUtils.h
@@ -1,0 +1,54 @@
+/*
+ Copyright Disney Enterprises, Inc.  All rights reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License
+ and the following modification to it: Section 6 Trademarks.
+ deleted and replaced with:
+
+ 6. Trademarks. This License does not grant permission to use the
+ trade names, trademarks, service marks, or product names of the
+ Licensor and its affiliates, except as required for reproducing
+ the content of the NOTICE file.
+
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+*/
+#ifndef StringUtils_h
+#define StringUtils_h
+
+#include <string>
+
+//! Unescape a few common special characters in the input @p string and return
+//! the result as a new one.
+inline std::string unescapeString(const std::string& string) {
+    std::string output(string);
+    int index = 0;
+    bool special = false;
+    for (char c : string) {
+        if (c == '\\') {
+            special = true;
+        } else {
+            if (special == true) {
+                special = false;
+                switch (c) {
+                    case 'n':   output[index++] = '\n'; break;
+                    case 'r':   output[index++] = '\r'; break;
+                    case 't':   output[index++] = '\t'; break;
+                    case '\\':  output[index++] = '\\'; break;
+                    case '"':   output[index++] = '\"'; break;
+                    default:
+                        // leave the escape sequence as it was
+                        output[index++] = '\\';
+                        output[index++] = c;
+                }
+            } else {
+                output[index++] = c;
+            }
+        }
+    }
+    output.resize(index);
+    return output;
+}
+
+#endif

--- a/src/tests/string.cpp
+++ b/src/tests/string.cpp
@@ -98,6 +98,13 @@ TEST(StringTests, Constant) {
     EXPECT_TRUE(expr.returnType().isString() == true);
     EXPECT_TRUE(expr.isConstant() == true);
     EXPECT_STREQ(expr.evalStr(), "hello world !");
+
+    // check that strings are correctly unescaped
+    StringExpression expr7("\"hello\\t\\n\\\"world\\\"\"");
+    EXPECT_TRUE(expr7.isValid() == true);
+    EXPECT_TRUE(expr7.returnType().isString() == true);
+    EXPECT_TRUE(expr7.isConstant() == true);
+    EXPECT_STREQ(expr7.evalStr(), "hello\t\n\"world\"");
 }
 
 TEST(StringTests, Variable) {


### PR DESCRIPTION
Currently when you create the following expression `"\"hello\""` the result will be `\"hello\"` instead of `"hello"` as we would expect.

This pull request fixes this by unescaping the most common special sequences in `ExprStrNode` instances (both in LLVM codegen and the interpreter)
I also added a small unit test, but I'm on Windows and I couldn't run them, so I hope it will pass ^^'

Note: I'm not sure if this is the best way of doing this, so don't hesitate to comment the pull request, tell me if I need to redo some parts, etc.

Regards,
Damien.