### PR TITLE
fixed dumb mistake in string un-escaping

### DIFF
--- a/src/SeExpr2/StringUtils.h
+++ b/src/SeExpr2/StringUtils.h
@@ -26,22 +26,22 @@ inline std::string unescapeString(const std::string& string) {
     int index = 0;
     bool special = false;
     for (char c : string) {
-        if (c == '\\') {
-            special = true;
+        if (special == true) {
+            special = false;
+            switch (c) {
+                case 'n':   output[index++] = '\n'; break;
+                case 'r':   output[index++] = '\r'; break;
+                case 't':   output[index++] = '\t'; break;
+                case '\\':  output[index++] = '\\'; break;
+                case '"':   output[index++] = '\"'; break;
+                default:
+                    // leave the escape sequence as it was
+                    output[index++] = '\\';
+                    output[index++] = c;
+            }
         } else {
-            if (special == true) {
-                special = false;
-                switch (c) {
-                    case 'n':   output[index++] = '\n'; break;
-                    case 'r':   output[index++] = '\r'; break;
-                    case 't':   output[index++] = '\t'; break;
-                    case '\\':  output[index++] = '\\'; break;
-                    case '"':   output[index++] = '\"'; break;
-                    default:
-                        // leave the escape sequence as it was
-                        output[index++] = '\\';
-                        output[index++] = c;
-                }
+            if (c == '\\') {
+                special = true;
             } else {
                 output[index++] = c;
             }

--- a/src/tests/string.cpp
+++ b/src/tests/string.cpp
@@ -100,11 +100,11 @@ TEST(StringTests, Constant) {
     EXPECT_STREQ(expr.evalStr(), "hello world !");
 
     // check that strings are correctly unescaped
-    StringExpression expr7("\"hello\\t\\n\\\"world\\\"\"");
+    StringExpression expr7("\"hello\\\\\\t\\n\\\"world\\\"\"");
     EXPECT_TRUE(expr7.isValid() == true);
     EXPECT_TRUE(expr7.returnType().isString() == true);
     EXPECT_TRUE(expr7.isConstant() == true);
-    EXPECT_STREQ(expr7.evalStr(), "hello\t\n\"world\"");
+    EXPECT_STREQ(expr7.evalStr(), "hello\\\t\n\"world\"");
 }
 
 TEST(StringTests, Variable) {


### PR DESCRIPTION
In one of my previous merge-request, I fixed a problem with strings special characters, but the small helper used was not very robust (the original merge-request was specifically added this to fix a common use-case in our integration, and the unit test was tailored to that use-case, so I totally missed the case that this current MR fixes)

Anyway now this should work properly (I updated the unit test to catch the problem of the current implementation) Hopefully since (almost) nobody uses strings, this pull request will be accepted before anyone notices :p