### PR TITLE
Build with pregenerated files when FLEX/BISON are missing.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,8 @@ else()
     endif()
 endif()
 
+set("PREGENERATED_ROOT" "${CMAKE_CURRENT_SOURCE_DIR}/windows7")
+
 # Set to release if nothing else defined
 if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,7 @@ set(SEEXPR_LLVM_LIBRARIES SeExpr2LLVM)
 set(SEEXPR_EDITOR_LIBRARIES SeExpr2Editor)
 
 # make it so seexpr can be found
-include_directories(BEFORE ${CMAKE_SOURCE_DIR}/src)
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 ## Traverse subdirectories
 add_subdirectory(src/SeExpr2)

--- a/src/SeExpr2/CMakeLists.txt
+++ b/src/SeExpr2/CMakeLists.txt
@@ -36,8 +36,8 @@ find_program(SED_EXE sed)
 if ((BISON_EXE STREQUAL "BISON_EXE-NOTFOUND") OR
     (FLEX_EXE STREQUAL "FLEX_EXE-NOTFOUND") OR
     (SED_EXE STREQUAL "SED_EXE-NOTFOUND"))
-    # don't have flex/bison/sed, use pregenerated versions
-    set(parser_cpp generated/ExprParser.cpp generated/ExprParserLex.cpp)
+  # don't have flex/bison/sed, use pregenerated versions
+    set(parser_cpp ${PREGENERATED_ROOT}/SeExpr/generated/ExprParser.cpp ${PREGENERATED_ROOT}/SeExpr/generated/ExprParserLex.cpp)
 else()
     ## build the parser from the flex/yacc sources
     add_custom_command(

--- a/src/SeExpr2/UI/CMakeLists.txt
+++ b/src/SeExpr2/UI/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(OpenGL)
 if (Qt5_FOUND OR QT4_FOUND)
 
     BuildParserScanner(ExprSpecParserLex ExprSpecParser ExprSpec
-                       editor_parser_cpp)
+                       editor_parser_cpp ui)
 
     set(EDITOR_MOC_HDRS ExprBrowser.h ExprColorCurve.h
         ExprColorSwatch.h ExprControlCollection.h

--- a/src/SeExpr2/UI/CMakeLists.txt
+++ b/src/SeExpr2/UI/CMakeLists.txt
@@ -86,7 +86,7 @@ if (Qt5_FOUND OR QT4_FOUND)
     set_property(TARGET SeExpr2Editor APPEND PROPERTY
                  COMPATIBLE_INTERFACE_STRING ${SeExpr2_MAJOR_VERSION})
 
-    include_directories(${CMAKE_BINARY_DIR}/src/SeExpr2)
+    include_directories(${CMAKE_CURRENT_BINARY_DIR}/../SeExpr2)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR})
     target_link_libraries(SeExpr2Editor SeExpr2)
 

--- a/src/build/macros.cmake
+++ b/src/build/macros.cmake
@@ -1,5 +1,5 @@
 
-macro(BuildParserScanner FLEX_L_PREFIX BISON_Y_PREFIX PARSER_PREFIX GENERATED_CPPS)
+macro(BuildParserScanner FLEX_L_PREFIX BISON_Y_PREFIX PARSER_PREFIX GENERATED_CPPS PREGENERATED_PREFIX)
   ## find our parser generators
   find_program(BISON_EXE bison)
   find_program(FLEX_EXE flex)
@@ -7,7 +7,7 @@ macro(BuildParserScanner FLEX_L_PREFIX BISON_Y_PREFIX PARSER_PREFIX GENERATED_CP
 
   if((BISON_EXE STREQUAL "BISON_EXE-NOTFOUND") OR (FLEX_EXE STREQUAL "FLEX_EXE-NOTFOUND")  OR (SED_EXE STREQUAL "SED_EXE-NOTFOUND"))
     # don't have flex/bison/sed, use pregenerated versions
-    set (${GENERATED_CPPS} generated/${BISON_Y_PREFIX}.cpp generated/${FLEX_L_PREFIX}.cpp )
+    set (${GENERATED_CPPS} ${PREGENERATED_ROOT}/${PREGENERATED_PREFIX}/generated/${BISON_Y_PREFIX}.cpp ${PREGENERATED_ROOT}/${PREGENERATED_PREFIX}/generated/${FLEX_L_PREFIX}.cpp )
   else ((BISON_EXE STREQUAL "BISON_EXE-NOTFOUND") OR (FLEX_EXE STREQUAL "FLEX_EXE-NOTFOUND")  OR (SED_EXE STREQUAL "SED_EXE-NOTFOUND"))
     ## build the parser from the flex/yacc sources
     

--- a/src/demos/CMakeLists.txt
+++ b/src/demos/CMakeLists.txt
@@ -13,7 +13,7 @@
 # You may obtain a copy of the License at
 # http://www.apache.org/licenses/LICENSE-2.0
 
-include_directories(${CMAKE_BINARY_DIR}/src/SeExpr2)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/../SeExpr2)
 
 add_executable(asciiGraph2 "asciiGraph.cpp")
 target_link_libraries(asciiGraph2 SeExpr2)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -13,7 +13,7 @@
 # You may obtain a copy of the License at
 # http://www.apache.org/licenses/LICENSE-2.0
 
-include_directories(${CMAKE_BINARY_DIR}/src/SeExpr2)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/../SeExpr2)
 
 set(TEST_DEST "share/test/SeExpr2")
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -13,7 +13,7 @@
 # You may obtain a copy of the License at
 # http://www.apache.org/licenses/LICENSE-2.0
 
-include_directories(${CMAKE_BINARY_DIR}/src/SeExpr2)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/../SeExpr2)
 
 foreach(item eval listVar)
     add_executable("${item}" "${item}.cpp")


### PR DESCRIPTION
Instead of having a manual copy step it's a bit more user friendly to just use them as they exist in the repository. Alternatively the file structure can/should be moved around.